### PR TITLE
Fix syntax errors reported by Clang.

### DIFF
--- a/glog/src/demangle.cc
+++ b/glog/src/demangle.cc
@@ -167,7 +167,7 @@ static size_t StrLen(const char *str) {
 // Returns true if "str" has at least "n" characters remaining.
 static bool AtLeastNumCharsRemaining(const char *str, int n) {
   for (int i = 0; i < n; ++i) {
-    if (str == '\0') {
+    if (str[i] == '\0') {
       return false;
     }
   }
@@ -223,7 +223,7 @@ static bool ParseTwoCharToken(State *state, const char *two_char_token) {
 // Returns true and advances "mangled_cur" if we find any character in
 // "char_class" at "mangled_cur" position.
 static bool ParseCharClass(State *state, const char *char_class) {
-  if (state->mangled_cur == '\0') {
+  if (*state->mangled_cur == '\0') {
     return false;
   }
   const char *p = char_class;

--- a/glog/src/symbolize.cc
+++ b/glog/src/symbolize.cc
@@ -232,7 +232,7 @@ bool GetSectionHeaderByName(int fd, const char *name, size_t name_len,
     }
     char header_name[kMaxSectionNameLen];
     if (sizeof(header_name) < name_len) {
-      RAW_LOG(WARNING, "Section name '%s' is too long (%"PRIuS"); "
+      RAW_LOG(WARNING, "Section name '%s' is too long (%" PRIuS "); "
               "section will not be found (even if present).", name, name_len);
       // No point in even trying.
       return false;


### PR DESCRIPTION
Dehao,

When building with Clang, it complained about a few invalid comparisons in glog/src. This patch fixes them. The one that was particularly bad was the first in glog/src/demangle.cc
