### PR TITLE
Support for newer kernels & remove openssl dependency

### DIFF
--- a/chromiumos-wide-profiling/kernel/perf_event.h
+++ b/chromiumos-wide-profiling/kernel/perf_event.h
@@ -137,8 +137,9 @@ enum perf_event_sample_format {
 	PERF_SAMPLE_DATA_SRC			= 1U << 15,
 	PERF_SAMPLE_IDENTIFIER			= 1U << 16,
 	PERF_SAMPLE_TRANSACTION			= 1U << 17,
+	PERF_SAMPLE_REGS_INTR			= 1U << 18,
 
-	PERF_SAMPLE_MAX = 1U << 18,		/* non-ABI */
+	PERF_SAMPLE_MAX = 1U << 19,		/* non-ABI */
 };
 
 /*
@@ -238,6 +239,7 @@ enum perf_event_read_format {
 #define PERF_ATTR_SIZE_VER2	80	/* add: branch_sample_type */
 #define PERF_ATTR_SIZE_VER3	96	/* add: sample_regs_user */
 					/* add: sample_stack_user */
+#define PERF_ATTR_SIZE_VER4	104	/* add: sample_regs_intr */
 
 /*
  * Hardware event_id to monitor via a performance monitoring event:
@@ -334,6 +336,15 @@ struct perf_event_attr {
 
 	/* Align to u64. */
 	__u32	__reserved_2;
+	/*
+	 * Defines set of regs to dump for each sample
+	 * state captured on:
+	 *  - precise = 0: PMU interrupt
+	 *  - precise > 0: sampled instruction
+	 *
+	 * See asm/perf_regs.h for details.
+	 */
+	__u64	sample_regs_intr;
 };
 
 #define perf_flags(attr)	(*(&(attr)->read_format + 1))
@@ -364,7 +375,7 @@ struct perf_event_mmap_page {
 	/*
 	 * Bits needed to read the hw events in user-space.
 	 *
-	 *   u32 seq, time_mult, time_shift, idx, width;
+	 *   u32 seq, time_mult, time_shift, index, width;
 	 *   u64 count, enabled, running;
 	 *   u64 cyc, time_offset;
 	 *   s64 pmc = 0;
@@ -383,11 +394,11 @@ struct perf_event_mmap_page {
 	 *       time_shift  = pc->time_shift;
 	 *     }
 	 *
-	 *     idx = pc->index;
+	 *     index = pc->index;
 	 *     count = pc->offset;
-	 *     if (pc->cap_usr_rdpmc && idx) {
+	 *     if (pc->cap_user_rdpmc && index) {
 	 *       width = pc->pmc_width;
-	 *       pmc = rdpmc(idx - 1);
+	 *       pmc = rdpmc(index - 1);
 	 *     }
 	 *
 	 *     barrier();
@@ -415,7 +426,7 @@ struct perf_event_mmap_page {
 	};
 
 	/*
-	 * If cap_usr_rdpmc this field provides the bit-width of the value
+	 * If cap_user_rdpmc this field provides the bit-width of the value
 	 * read using the rdpmc() or equivalent instruction. This can be used
 	 * to sign extend the result like:
 	 *
@@ -439,10 +450,10 @@ struct perf_event_mmap_page {
 	 *
 	 * Where time_offset,time_mult,time_shift and cyc are read in the
 	 * seqcount loop described above. This delta can then be added to
-	 * enabled and possible running (if idx), improving the scaling:
+	 * enabled and possible running (if index), improving the scaling:
 	 *
 	 *   enabled += delta;
-	 *   if (idx)
+	 *   if (index)
 	 *     running += delta;
 	 *
 	 *   quot = count / running;
@@ -686,6 +697,8 @@ enum perf_event_type {
 	 *	{ u64			weight;   } && PERF_SAMPLE_WEIGHT
 	 *	{ u64			data_src; } && PERF_SAMPLE_DATA_SRC
 	 *	{ u64			transaction; } && PERF_SAMPLE_TRANSACTION
+	 *	{ u64			abi; # enum perf_sample_regs_abi
+	 *	  u64			regs[weight(mask)]; } && PERF_SAMPLE_REGS_INTR
 	 * };
 	 */
 	PERF_RECORD_SAMPLE			= 9,

--- a/chromiumos-wide-profiling/perf_parser.cc
+++ b/chromiumos-wide-profiling/perf_parser.cc
@@ -174,6 +174,7 @@ bool PerfParser::ProcessEvents() {
       case PERF_RECORD_UNTHROTTLE:
       case PERF_RECORD_READ:
       case PERF_RECORD_MAX:
+      case PERF_RECORD_FINISHED_ROUND:
         VLOG(1) << "Parsed event type: " << event.header.type
                 << ". Doing nothing.";
         break;
@@ -222,8 +223,9 @@ void PerfParser::MaybeSortParsedEvents() {
     event_and_time->event = &parsed_events_[i];
 
     struct perf_sample sample_info;
-    CHECK(reader_.ReadPerfSampleInfo(*parsed_events_[i].raw_event,
-                                     &sample_info));
+    if (reader_.ReadPerfSampleInfo(*parsed_events_[i].raw_event,
+                                     &sample_info) == false)
+      continue;
     event_and_time->time = sample_info.time;
 
     events_and_times[i] = std::move(event_and_time);

--- a/chromiumos-wide-profiling/perf_reader.cc
+++ b/chromiumos-wide-profiling/perf_reader.cc
@@ -220,10 +220,7 @@ void CheckNoPerfEventAttrPadding() {
   CHECK_EQ(sizeof(attr),
            (reinterpret_cast<u64>(&attr.__reserved_2) -
             reinterpret_cast<u64>(&attr)) +
-           sizeof(attr.branch_sample_type) +
-	   sizeof(attr.sample_regs_user) +
-	   sizeof(attr.sample_stack_user) +
-	   sizeof(attr.__reserved_2) +
+	   4 +
 	   sizeof(attr.sample_regs_intr));
 }
 
@@ -1095,7 +1092,13 @@ bool PerfReader::IsSupportedEventType(uint32_t type) {
 
 bool PerfReader::ReadPerfSampleInfo(const event_t& event,
                                     struct perf_sample* sample) const {
+
   CHECK(sample);
+
+  if (event.header.type >= PERF_RECORD_USER_TYPE_START && event.header.type < PERF_RECORD_HEADER_MAX) {
+    memset(sample, 0, sizeof(perf_sample));
+    return true;
+  }
 
   if (!IsSupportedEventType(event.header.type)) {
     LOG(ERROR) << "Unsupported event type " << event.header.type;
@@ -1814,6 +1817,9 @@ bool PerfReader::ReadPipedData(const ConstBufferWithSize& data) {
     }
 
     switch (header.type) {
+    case PERF_RECORD_FINISHED_ROUND:
+      result = true;
+      break;
     case PERF_RECORD_HEADER_ATTR:
       result = ReadAttrEventBlock(data, new_offset, size_without_header);
       break;

--- a/chromiumos-wide-profiling/perf_reader.cc
+++ b/chromiumos-wide-profiling/perf_reader.cc
@@ -220,7 +220,11 @@ void CheckNoPerfEventAttrPadding() {
   CHECK_EQ(sizeof(attr),
            (reinterpret_cast<u64>(&attr.__reserved_2) -
             reinterpret_cast<u64>(&attr)) +
-           sizeof(attr.__reserved_2));
+           sizeof(attr.branch_sample_type) +
+	   sizeof(attr.sample_regs_user) +
+	   sizeof(attr.sample_stack_user) +
+	   sizeof(attr.__reserved_2) +
+	   sizeof(attr.sample_regs_intr));
 }
 
 void CheckNoEventTypePadding() {

--- a/chromiumos-wide-profiling/utils.cc
+++ b/chromiumos-wide-profiling/utils.cc
@@ -4,7 +4,11 @@
 
 #include "chromiumos-wide-profiling/utils.h"
 
+#define NO_MD5 1
+
+#ifndef NO_MD5
 #include <openssl/md5.h>
+#endif
 #include <sys/stat.h>
 
 #include <cctype>
@@ -60,6 +64,9 @@ build_id_event* CallocMemoryForBuildID(size_t size) {
 static uint64_t Md5Prefix(
     const unsigned char* data,
     unsigned long length) { // NOLINT
+#ifdef NO_MD5
+  return 0;
+#else
   uint64_t digest_prefix = 0;
   unsigned char digest[MD5_DIGEST_LENGTH + 1];
 
@@ -73,6 +80,7 @@ static uint64_t Md5Prefix(
        << static_cast<unsigned int>(digest[i]);
   ss >> digest_prefix;
   return digest_prefix;
+#endif
 }
 
 uint64_t Md5Prefix(const string& input) {


### PR DESCRIPTION
This patch kit updates quipper to support recent kernels, and also removes an unnecessary openssl dependency.
