### PR TITLE
Fix use of -rpath

### DIFF
--- a/configure
+++ b/configure
@@ -4804,7 +4804,7 @@ fi
                       -ldl -lpthread -ltinfo"
       elif test "x$shared_mode" = "xshared"; then
         rpath="$($ac_llvm_config_path --libdir)"
-        LLVM_LDFLAGS="-rpath $rpath \
+        LLVM_LDFLAGS="-Wl,-rpath $rpath \
                       $($ac_llvm_config_path --ldflags) \
                       $($ac_llvm_config_path --libs ProfileData)"
       fi

--- a/m4/ax_llvm.m4
+++ b/m4/ax_llvm.m4
@@ -67,7 +67,7 @@ AC_DEFUN([AX_LLVM],
                       -ldl -lpthread -ltinfo"
       elif test "x$shared_mode" = "xshared"; then
         rpath="$($ac_llvm_config_path --libdir)"
-        LLVM_LDFLAGS="-rpath $rpath \
+        LLVM_LDFLAGS="-Wl,-rpath $rpath \
                       $($ac_llvm_config_path --ldflags) \
                       $($ac_llvm_config_path --libs $1)"
       fi


### PR DESCRIPTION
Instruct the compiler to send the -rpath flag to the linker, otherwise the
compiler fails like this:

g++: error: unrecognized command line option ‘-rpath’