### PR TITLE
auto-fdo: add missing perf event type

### DIFF
--- a/chromiumos-wide-profiling/kernel/perf_event.h
+++ b/chromiumos-wide-profiling/kernel/perf_event.h
@@ -712,6 +712,7 @@ enum perf_event_type {
 	 */
 	PERF_RECORD_MMAP2			= 10,
 
+        PERF_RECORD_FINISHED_ROUND              = 68,
 	PERF_RECORD_MAX,			/* non-ABI */
 };
 

--- a/chromiumos-wide-profiling/perf_parser.cc
+++ b/chromiumos-wide-profiling/perf_parser.cc
@@ -182,6 +182,7 @@ bool PerfParser::ProcessEvents() {
       case PERF_RECORD_UNTHROTTLE:
       case PERF_RECORD_READ:
       case PERF_RECORD_MAX:
+      case PERF_RECORD_FINISHED_ROUND:
         VLOG(1) << "Parsed event type: " << event.header.type
                 << ". Doing nothing.";
         break;


### PR DESCRIPTION
create_gcov used to produce an error:
E1214 09:52:52.811347 20266 perf_parser.cc:189] Unknown event type: 68

that is fixed by this patch.  There is nothing to be done on decoding a
PERF_RECORD_FINISHED_ROUND.