### PR TITLE
Newer perf+atom

### DIFF
--- a/chromiumos-wide-profiling/kernel/perf_event.h
+++ b/chromiumos-wide-profiling/kernel/perf_event.h
@@ -712,8 +712,29 @@ enum perf_event_type {
 	 */
 	PERF_RECORD_MMAP2			= 10,
 
-        PERF_RECORD_FINISHED_ROUND              = 68,
 	PERF_RECORD_MAX,			/* non-ABI */
+};
+
+enum perf_user_event_type { /* above any possible kernel type */
+        PERF_RECORD_USER_TYPE_START             = 64,
+        PERF_RECORD_HEADER_ATTR                 = 64,
+        PERF_RECORD_HEADER_EVENT_TYPE           = 65, /* depreceated */
+        PERF_RECORD_HEADER_TRACING_DATA         = 66,
+        PERF_RECORD_HEADER_BUILD_ID             = 67,
+        PERF_RECORD_FINISHED_ROUND              = 68,
+        PERF_RECORD_ID_INDEX                    = 69,
+        PERF_RECORD_AUXTRACE_INFO               = 70,
+        PERF_RECORD_AUXTRACE                    = 71,
+        PERF_RECORD_AUXTRACE_ERROR              = 72,
+        PERF_RECORD_THREAD_MAP                  = 73,
+        PERF_RECORD_CPU_MAP                     = 74,
+        PERF_RECORD_STAT_CONFIG                 = 75,
+        PERF_RECORD_STAT                        = 76,
+        PERF_RECORD_STAT_ROUND                  = 77,
+        PERF_RECORD_EVENT_UPDATE                = 78,
+        PERF_RECORD_TIME_CONV                   = 79,
+	/* Predicting the future */
+        PERF_RECORD_HEADER_MAX			= 100,
 };
 
 #define PERF_MAX_STACK_DEPTH		127

--- a/chromiumos-wide-profiling/perf_parser.cc
+++ b/chromiumos-wide-profiling/perf_parser.cc
@@ -181,8 +181,7 @@ bool PerfParser::ProcessEvents() {
       case PERF_RECORD_THROTTLE:
       case PERF_RECORD_UNTHROTTLE:
       case PERF_RECORD_READ:
-      case PERF_RECORD_MAX:
-      case PERF_RECORD_FINISHED_ROUND:
+      case PERF_RECORD_USER_TYPE_START ... PERF_RECORD_HEADER_MAX:
         VLOG(1) << "Parsed event type: " << event.header.type
                 << ". Doing nothing.";
         break;

--- a/chromiumos-wide-profiling/perf_parser.cc
+++ b/chromiumos-wide-profiling/perf_parser.cc
@@ -400,11 +400,7 @@ bool PerfParser::MapBranchStack(const uint32_t pid,
     parsed_entry.predicted = entry.flags.predicted;
     // Either predicted or mispredicted, not both. But don't use a CHECK here,
     // just exit gracefully because it's a minor issue.
-    if (entry.flags.predicted == entry.flags.mispred) {
-      LOG(ERROR) << "Branch stack entry predicted and mispred flags "
-                 << "both have value " << entry.flags.mispred;
-      return false;
-    }
+    // We can't check this because Atom doesn't have predicted/mispredicted flags
   }
 
   return true;

--- a/chromiumos-wide-profiling/perf_reader.cc
+++ b/chromiumos-wide-profiling/perf_reader.cc
@@ -995,6 +995,12 @@ bool PerfReader::IsSupportedEventType(uint32_t type) {
 bool PerfReader::ReadPerfSampleInfo(const event_t& event,
                                     struct perf_sample* sample) const {
   CHECK(sample);
+  unsigned type = event.header.type;
+
+  /* Ignore events added by perf record */
+  if (type >= PERF_RECORD_USER_TYPE_START &&
+      type < PERF_RECORD_HEADER_MAX)
+    return true;
 
   if (!IsSupportedEventType(event.header.type)) {
     LOG(ERROR) << "Unsupported event type " << event.header.type;


### PR DESCRIPTION
Here are two patches fixing autofdo for newer perf versions and for Atom CPUs.
