### PR TITLE
Fix path truncation in profile_creator

### DIFF
--- a/profile_creator.cc
+++ b/profile_creator.cc
@@ -54,20 +54,17 @@ bool ProfileCreator::CreateProfile(const string &input_profile_name,
 bool ProfileCreator::ReadSample(const string &input_profile_name,
                                 const string &profiler) {
   if (profiler == "perf") {
-    // Sets the regular expression to filter samples for a given binary.
-    char *dup_name = strdup(binary_.c_str());
-    char *strip_ptr = strstr(dup_name, ".unstripped");
-    if (strip_ptr) {
-      *strip_ptr = 0;
+    string file_base_name = basename(binary_.c_str());
+    size_t unstripped_at = file_base_name.find(".unstripped");
+    if (unstripped_at != string::npos) {
+      file_base_name.erase(unstripped_at);
     }
-    const char *file_base_name = basename(dup_name);
-    CHECK(file_base_name) << "Cannot find basename for: " << binary_;
+    CHECK(!file_base_name.empty()) << "Cannot find basename for: " << binary_;
 
     ElfReader reader(binary_);
 
     sample_reader_ = new PerfDataSampleReader(
-        input_profile_name, file_base_name);
-    free(dup_name);
+        input_profile_name, std::move(file_base_name));
   } else if (profiler == "text") {
     sample_reader_ = new TextSampleReaderWriter(input_profile_name);
   } else {


### PR DESCRIPTION
Currently, given a binary_ at a path that looks like
/foo/bar.unstripped/baz.so, file_base_name ends up being "bar". That
doesn't seem like the intention of this piece of code (and was a lot of
fun to debug ;) ).

Make it so that ".unstripped" can only be removed from the basename.

(I'd imagine that we would only want to remove ".unstripped" if it's at
the very end of the file name, but I'm less sure of that, so this patch
doesn't require that ".unstripped" is at the end. Happy to add that
check in if you'd like.)