### PR TITLE
Ensure initialized dir_name and func_name in SourceInfo

### DIFF
--- a/source_info.h
+++ b/source_info.h
@@ -27,7 +27,13 @@ namespace autofdo {
 
 // Represents the source position.
 struct SourceInfo {
-  SourceInfo() : func_name(NULL), start_line(0), line(0), discriminator(0) {}
+  SourceInfo()
+      : func_name(NULL),
+        dir_name(NULL),
+        file_name(NULL),
+        start_line(0),
+        line(0),
+        discriminator(0) {}
 
   SourceInfo(const char *func_name, const char *dir_name,
              const char *file_name, uint32 start_line, uint32 line,


### PR DESCRIPTION
This fixes a SIGSEGV I encountered while using create_llvm_prof --debug_dump.