### PR TITLE
Update Makefile.am to build quipper perf_data.proto's and perf_stat.proto's source and header files.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,6 +13,21 @@ $(PROTOBUF)/src/.libs/libprotobuf.a: $(PROTOBUF)/configure
 	(cd third_party/protobuf/; CC="$(CC)" CXX="$(CXX)" LDFLAGS="$(LDFLAGS_$(CONFIG)) -g $(PROTOBUF_LDFLAGS_EXTRA)" CPPFLAGS="$(PIC_CPPFLAGS) $(CPPFLAGS_$(CONFIG)) -g $(PROTOBUF_CPPFLAGS_EXTRA)" ./configure --disable-shared --enable-static $(PROTOBUF_CONFIG_OPTS))
 	make -C $(PROTOBUF)
 
+protoc_inputs = \
+	third_party/perf_data_converter/src/quipper/perf_data.proto \
+	third_party/perf_data_converter/src/quipper/perf_stat.proto
+
+protoc_outputs = \
+	third_party/perf_data_converter/src/quipper/perf_data.pb.cc \
+	third_party/perf_data_converter/src/quipper/perf_data.pb.h \
+	third_party/perf_data_converter/src/quipper/perf_stat.pb.cc \
+	third_party/perf_data_converter/src/quipper/perf_stat.pb.h
+
+generate_protoc_outputs: $(protoc_inputs) $(PROTOBUF)/src/.libs/libprotobuf.a
+	$(PROTOC) --cpp_out=`dirname $<` -I`dirname $<` $(protoc_inputs)
+
+$(protoc_outputs): generate_protoc_outputs
+
 ACLOCAL_AMFLAGS = -I m4
 AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/glog/src -I$(top_srcdir)/third_party/perf_data_converter/src/quipper
 AM_CXXFLAGS = -std=gnu++11 -I./$(PROTOBUF)/src
@@ -23,9 +38,12 @@ COMMON_PROFILE_CREATOR_FILES = addr2line.cc gcov.cc instruction_map.cc \
                                profile_writer.cc sample_reader.cc \
                                source_info.cc symbol_map.cc profile.cc
 
+
 bin_PROGRAMS = create_gcov
 create_gcov_SOURCES = $(COMMON_PROFILE_CREATOR_FILES) create_gcov.cc
 create_gcov_LDADD = libquipper.a libglog.a libsymbolize.a libgflags.a $(PROTOBUF_DEP)
+nodist_create_gcov_SOURCES = $(protoc_outputs)
+$(am_create_gcov_OBJECTS): generate_protoc_outputs
 
 bin_PROGRAMS += dump_gcov
 dump_gcov_SOURCES = profile_reader.cc symbol_map.cc module_grouper.cc gcov.cc \
@@ -35,21 +53,29 @@ dump_gcov_LDADD = libglog.a libgflags.a libsymbolize.a
 bin_PROGRAMS += sample_merger
 sample_merger_SOURCES = $(COMMON_PROFILE_CREATOR_FILES) sample_merger.cc
 sample_merger_LDADD = libquipper.a libglog.a libsymbolize.a libgflags.a $(PROTOBUF_DEP)
+nodist_sample_merger_SOURCES = $(protoc_outputs)
+$(am_sample_merger_OBJECTS): generate_protoc_outputs
 
 bin_PROGRAMS += profile_merger
 profile_merger_SOURCES = $(COMMON_PROFILE_CREATOR_FILES) profile_reader.cc \
                          profile_merger.cc
 profile_merger_LDADD = libquipper.a libglog.a libsymbolize.a libgflags.a $(PROTOBUF_DEP)
+nodist_profile_merger_SOURCES = $(protoc_outputs)
+$(am_profile_merger_OBJECTS): generate_protoc_outputs
 
 bin_PROGRAMS += profile_diff
 profile_diff_SOURCES = $(COMMON_PROFILE_CREATOR_FILES) profile_reader.cc \
                        profile_diff.cc
 profile_diff_LDADD = libquipper.a libglog.a libsymbolize.a libgflags.a $(PROTOBUF_DEP)
+nodist_profile_diff_SOURCES = $(protoc_outputs)
+$(am_profile_diff_OBJECTS): generate_protoc_outputs
 
 bin_PROGRAMS += profile_update
 profile_update_SOURCES = $(COMMON_PROFILE_CREATOR_FILES) profile_reader.cc \
                          profile_update.cc
 profile_update_LDADD = libquipper.a libglog.a libsymbolize.a libgflags.a $(PROTOBUF_DEP)
+nodist_profile_update_SOURCES = $(protoc_outputs)
+$(am_profile_update_OBJECTS): generate_protoc_outputs
 
 bin_PROGRAMS += create_llvm_prof
 create_llvm_prof_SOURCES = $(COMMON_PROFILE_CREATOR_FILES) \
@@ -57,13 +83,8 @@ create_llvm_prof_SOURCES = $(COMMON_PROFILE_CREATOR_FILES) \
 create_llvm_prof_LDADD = $(LLVM_LDFLAGS) $(LLVM_LIBS) libquipper.a libglog.a \
                          libsymbolize.a libgflags.a $(PROTOBUF_DEP)
 create_llvm_prof_CXXFLAGS = $(LLVM_CXXFLAGS) -DCREATE_LLVM_PROF
-
-dist_noinst_DATA = \
-	third_party/perf_data_converter/src/quipper/perf_data.proto \
-	third_party/perf_data_converter/src/quipper/perf_stat.proto
-
-%.pb.cc %.pb.h: %.proto $(PROTOBUF)/src/.libs/libprotobuf.a
-	$(PROTOC) --cpp_out=`dirname $<` -I`dirname $<` $<
+nodist_create_llvm_prof_SOURCES = $(protoc_outputs)
+$(am_create_llvm_prof_OBJECTS): generate_protoc_outputs
 
 noinst_LIBRARIES = libquipper.a
 libquipper_a_SOURCES = \
@@ -81,9 +102,9 @@ libquipper_a_SOURCES = \
 	third_party/perf_data_converter/src/quipper/perf_reader.cc \
 	third_party/perf_data_converter/src/quipper/perf_serializer.cc \
 	third_party/perf_data_converter/src/quipper/sample_info_reader.cc \
-	third_party/perf_data_converter/src/quipper/huge_page_deducer.cc \
-	third_party/perf_data_converter/src/quipper/perf_data.pb.cc \
-	third_party/perf_data_converter/src/quipper/perf_stat.pb.cc
+	third_party/perf_data_converter/src/quipper/huge_page_deducer.cc
+nodist_libquipper_a_SOURCES = $(protoc_outputs)
+$(am_libquipper_a_OBJECTS): generate_protoc_outputs
 
 noinst_LIBRARIES += libglog.a
 libglog_a_SOURCES = glog/src/glog/log_severity.h \


### PR DESCRIPTION
Fixes: #69