### PR TITLE
Build fixes to generate protobuffer files and fix link order

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -29,7 +29,8 @@ $(protoc_outputs): $(protoc_inputs) $(PROTOC)
 ACLOCAL_AMFLAGS = -I m4
 AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/glog/src -I$(top_srcdir)/third_party/perf_data_converter/src/quipper -I./$(PROTOBUF)/src
 AM_CXXFLAGS = -std=gnu++11 -I./$(PROTOBUF)/src
-AM_LDFLAGS = -lpthread -lelf -lz
+LIBS += -lpthread
+LIBELF = -lelf
 
 COMMON_PROFILE_CREATOR_FILES = addr2line.cc gcov.cc instruction_map.cc \
                                module_grouper.cc profile_creator.cc \
@@ -39,7 +40,7 @@ COMMON_PROFILE_CREATOR_FILES = addr2line.cc gcov.cc instruction_map.cc \
 
 bin_PROGRAMS = create_gcov
 create_gcov_SOURCES = $(COMMON_PROFILE_CREATOR_FILES) create_gcov.cc
-create_gcov_LDADD = libquipper.a libglog.a libsymbolize.a libgflags.a $(PROTOBUF_DEP)
+create_gcov_LDADD = libquipper.a libglog.a libsymbolize.a libgflags.a $(LIBELF) $(PROTOBUF_DEP)
 nodist_create_gcov_SOURCES = $(protoc_outputs)
 $(am_create_gcov_OBJECTS): $(protoc_outputs)
 
@@ -50,28 +51,28 @@ dump_gcov_LDADD = libglog.a libgflags.a libsymbolize.a
 
 bin_PROGRAMS += sample_merger
 sample_merger_SOURCES = $(COMMON_PROFILE_CREATOR_FILES) sample_merger.cc
-sample_merger_LDADD = libquipper.a libglog.a libsymbolize.a libgflags.a $(PROTOBUF_DEP)
+sample_merger_LDADD = libquipper.a libglog.a libsymbolize.a libgflags.a $(LIBELF) $(PROTOBUF_DEP)
 nodist_sample_merger_SOURCES = $(protoc_outputs)
 $(am_sample_merger_OBJECTS): $(protoc_outputs)
 
 bin_PROGRAMS += profile_merger
 profile_merger_SOURCES = $(COMMON_PROFILE_CREATOR_FILES) profile_reader.cc \
                          profile_merger.cc
-profile_merger_LDADD = libquipper.a libglog.a libsymbolize.a libgflags.a $(PROTOBUF_DEP)
+profile_merger_LDADD = libquipper.a libglog.a libsymbolize.a libgflags.a $(LIBELF) $(PROTOBUF_DEP)
 nodist_profile_merger_SOURCES = $(protoc_outputs)
 $(am_profile_merger_OBJECTS): $(protoc_outputs)
 
 bin_PROGRAMS += profile_diff
 profile_diff_SOURCES = $(COMMON_PROFILE_CREATOR_FILES) profile_reader.cc \
                        profile_diff.cc
-profile_diff_LDADD = libquipper.a libglog.a libsymbolize.a libgflags.a $(PROTOBUF_DEP)
+profile_diff_LDADD = libquipper.a libglog.a libsymbolize.a libgflags.a $(LIBELF) $(PROTOBUF_DEP)
 nodist_profile_diff_SOURCES = $(protoc_outputs)
 $(am_profile_diff_OBJECTS): $(protoc_outputs)
 
 bin_PROGRAMS += profile_update
 profile_update_SOURCES = $(COMMON_PROFILE_CREATOR_FILES) profile_reader.cc \
                          profile_update.cc
-profile_update_LDADD = libquipper.a libglog.a libsymbolize.a libgflags.a $(PROTOBUF_DEP)
+profile_update_LDADD = libquipper.a libglog.a libsymbolize.a libgflags.a $(LIBELF) $(PROTOBUF_DEP)
 nodist_profile_update_SOURCES = $(protoc_outputs)
 $(am_profile_update_OBJECTS): $(protoc_outputs)
 
@@ -79,7 +80,7 @@ bin_PROGRAMS += create_llvm_prof
 create_llvm_prof_SOURCES = $(COMMON_PROFILE_CREATOR_FILES) \
                            llvm_profile_writer.cc create_llvm_prof.cc
 create_llvm_prof_LDADD = $(LLVM_LDFLAGS) $(LLVM_LIBS) libquipper.a libglog.a \
-                         libsymbolize.a libgflags.a $(PROTOBUF_DEP)
+                         libsymbolize.a libgflags.a $(LIBELF) $(PROTOBUF_DEP)
 create_llvm_prof_CXXFLAGS = $(LLVM_CXXFLAGS) -DCREATE_LLVM_PROF
 nodist_create_llvm_prof_SOURCES = $(protoc_outputs)
 $(am_create_llvm_prof_OBJECTS): $(protoc_outputs)

--- a/Makefile.am
+++ b/Makefile.am
@@ -27,7 +27,7 @@ $(protoc_outputs): $(protoc_inputs) $(PROTOC)
 	$(PROTOC) --cpp_out=`dirname $<` -I`dirname $<` $(protoc_inputs)
 
 ACLOCAL_AMFLAGS = -I m4
-AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/glog/src -I$(top_srcdir)/third_party/perf_data_converter/src/quipper
+AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/glog/src -I$(top_srcdir)/third_party/perf_data_converter/src/quipper -I./$(PROTOBUF)/src
 AM_CXXFLAGS = -std=gnu++11 -I./$(PROTOBUF)/src
 AM_LDFLAGS = -lpthread -lelf -lz
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -8,10 +8,23 @@ $(PROTOBUF)/configure:
 	echo "[AUTOGEN] Preparing protobuf"
 	(cd $(PROTOBUF) ; autoreconf -f -i -Wall,no-obsolete)
 
-$(PROTOBUF)/src/.libs/libprotobuf.a: $(PROTOBUF)/configure
+$(PROTOC) $(PROTOBUF)/src/.libs/libprotobuf.a: $(PROTOBUF)/configure
 	echo "[MAKE] Building protobuf"
 	(cd third_party/protobuf/; CC="$(CC)" CXX="$(CXX)" LDFLAGS="$(LDFLAGS_$(CONFIG)) -g $(PROTOBUF_LDFLAGS_EXTRA)" CPPFLAGS="$(PIC_CPPFLAGS) $(CPPFLAGS_$(CONFIG)) -g $(PROTOBUF_CPPFLAGS_EXTRA)" ./configure --disable-shared --enable-static $(PROTOBUF_CONFIG_OPTS))
 	make -C $(PROTOBUF)
+
+protoc_inputs = \
+	third_party/perf_data_converter/src/quipper/perf_data.proto \
+	third_party/perf_data_converter/src/quipper/perf_stat.proto
+
+protoc_outputs = \
+	third_party/perf_data_converter/src/quipper/perf_data.pb.cc \
+	third_party/perf_data_converter/src/quipper/perf_data.pb.h \
+	third_party/perf_data_converter/src/quipper/perf_stat.pb.cc \
+	third_party/perf_data_converter/src/quipper/perf_stat.pb.h
+
+$(protoc_outputs): $(protoc_inputs) $(PROTOC)
+	$(PROTOC) --cpp_out=`dirname $<` -I`dirname $<` $(protoc_inputs)
 
 ACLOCAL_AMFLAGS = -I m4
 AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/glog/src -I$(top_srcdir)/third_party/perf_data_converter/src/quipper
@@ -23,9 +36,12 @@ COMMON_PROFILE_CREATOR_FILES = addr2line.cc gcov.cc instruction_map.cc \
                                profile_writer.cc sample_reader.cc \
                                source_info.cc symbol_map.cc profile.cc
 
+
 bin_PROGRAMS = create_gcov
 create_gcov_SOURCES = $(COMMON_PROFILE_CREATOR_FILES) create_gcov.cc
 create_gcov_LDADD = libquipper.a libglog.a libsymbolize.a libgflags.a $(PROTOBUF_DEP)
+nodist_create_gcov_SOURCES = $(protoc_outputs)
+$(am_create_gcov_OBJECTS): $(protoc_outputs)
 
 bin_PROGRAMS += dump_gcov
 dump_gcov_SOURCES = profile_reader.cc symbol_map.cc module_grouper.cc gcov.cc \
@@ -35,21 +51,29 @@ dump_gcov_LDADD = libglog.a libgflags.a libsymbolize.a
 bin_PROGRAMS += sample_merger
 sample_merger_SOURCES = $(COMMON_PROFILE_CREATOR_FILES) sample_merger.cc
 sample_merger_LDADD = libquipper.a libglog.a libsymbolize.a libgflags.a $(PROTOBUF_DEP)
+nodist_sample_merger_SOURCES = $(protoc_outputs)
+$(am_sample_merger_OBJECTS): $(protoc_outputs)
 
 bin_PROGRAMS += profile_merger
 profile_merger_SOURCES = $(COMMON_PROFILE_CREATOR_FILES) profile_reader.cc \
                          profile_merger.cc
 profile_merger_LDADD = libquipper.a libglog.a libsymbolize.a libgflags.a $(PROTOBUF_DEP)
+nodist_profile_merger_SOURCES = $(protoc_outputs)
+$(am_profile_merger_OBJECTS): $(protoc_outputs)
 
 bin_PROGRAMS += profile_diff
 profile_diff_SOURCES = $(COMMON_PROFILE_CREATOR_FILES) profile_reader.cc \
                        profile_diff.cc
 profile_diff_LDADD = libquipper.a libglog.a libsymbolize.a libgflags.a $(PROTOBUF_DEP)
+nodist_profile_diff_SOURCES = $(protoc_outputs)
+$(am_profile_diff_OBJECTS): $(protoc_outputs)
 
 bin_PROGRAMS += profile_update
 profile_update_SOURCES = $(COMMON_PROFILE_CREATOR_FILES) profile_reader.cc \
                          profile_update.cc
 profile_update_LDADD = libquipper.a libglog.a libsymbolize.a libgflags.a $(PROTOBUF_DEP)
+nodist_profile_update_SOURCES = $(protoc_outputs)
+$(am_profile_update_OBJECTS): $(protoc_outputs)
 
 bin_PROGRAMS += create_llvm_prof
 create_llvm_prof_SOURCES = $(COMMON_PROFILE_CREATOR_FILES) \
@@ -57,13 +81,8 @@ create_llvm_prof_SOURCES = $(COMMON_PROFILE_CREATOR_FILES) \
 create_llvm_prof_LDADD = $(LLVM_LDFLAGS) $(LLVM_LIBS) libquipper.a libglog.a \
                          libsymbolize.a libgflags.a $(PROTOBUF_DEP)
 create_llvm_prof_CXXFLAGS = $(LLVM_CXXFLAGS) -DCREATE_LLVM_PROF
-
-dist_noinst_DATA = \
-	third_party/perf_data_converter/src/quipper/perf_data.proto \
-	third_party/perf_data_converter/src/quipper/perf_stat.proto
-
-%.pb.cc %.pb.h: %.proto $(PROTOBUF)/src/.libs/libprotobuf.a
-	$(PROTOC) --cpp_out=`dirname $<` -I`dirname $<` $<
+nodist_create_llvm_prof_SOURCES = $(protoc_outputs)
+$(am_create_llvm_prof_OBJECTS): $(protoc_outputs)
 
 noinst_LIBRARIES = libquipper.a
 libquipper_a_SOURCES = \
@@ -81,9 +100,9 @@ libquipper_a_SOURCES = \
 	third_party/perf_data_converter/src/quipper/perf_reader.cc \
 	third_party/perf_data_converter/src/quipper/perf_serializer.cc \
 	third_party/perf_data_converter/src/quipper/sample_info_reader.cc \
-	third_party/perf_data_converter/src/quipper/huge_page_deducer.cc \
-	third_party/perf_data_converter/src/quipper/perf_data.pb.cc \
-	third_party/perf_data_converter/src/quipper/perf_stat.pb.cc
+	third_party/perf_data_converter/src/quipper/huge_page_deducer.cc
+nodist_libquipper_a_SOURCES = $(protoc_outputs)
+$(am_libquipper_a_OBJECTS): $(protoc_outputs)
 
 noinst_LIBRARIES += libglog.a
 libglog_a_SOURCES = glog/src/glog/log_severity.h \

--- a/README
+++ b/README
@@ -21,7 +21,10 @@ dependencies, and:
 
 aclocal -I .; autoheader; autoconf; automake --add-missing -c
 ./configure # or --with-llvm=$(which llvm-config-5.0)
-make -j$(nproc)
+make
+
+(Note: do not use the '-j' (parallel build) option of make. The configure scripts
+ for the sub-projects fail if run in parallel)
 
 Usage:
 ./create_gcov --binary=BINARY --profile=PERF_PROFILE --gcov=OUTPUT


### PR DESCRIPTION
The protocol buffer files need to be generated before build.  This takes the fix from #70, but fixes the dependencies so that they aren't regenerated on each "make" invocation.

Some linkers will drop libraries that haven't been referenced by any file/library previously used on the command line.  This means that the pthread and elf libraries which appear at the beginning of the command line are dropped, causing the build failures reported in #69