### PR TITLE
Support for cache prefetching profiles.

### DIFF
--- a/create_llvm_prof.cc
+++ b/create_llvm_prof.cc
@@ -24,7 +24,9 @@
 #include "llvm_profile_writer.h"
 
 DEFINE_string(profile, "perf.data", "Input profile file name");
-DEFINE_string(profiler, "perf", "Input profile type");
+DEFINE_string(profiler, "perf",
+              "Input profile type. Possible values: perf, text, or prefetch");
+DEFINE_string(prefetch_hints, "", "Input cache prefetch hints");
 DEFINE_string(out, "", "Output profile file name");
 DEFINE_string(gcov, "",
               "Output profile file name. Alias for --out; used for "

--- a/profile_creator.cc
+++ b/profile_creator.cc
@@ -28,6 +28,50 @@
 #include "symbolize/elf_reader.h"
 #include "module_grouper.h"
 
+namespace {
+struct PrefetchHint {
+  uint64 address;
+  int64 delta;
+  string type;
+};
+
+typedef std::vector<PrefetchHint> PrefetchHints;
+
+// Experimental support for providing cache prefetch hints.
+// Currently, the format is a simple csv format, with no superfluous spaces or
+// markers (e.g. quotes).
+// Each line has 3 values:
+//   - a PC (hex), corresponding to a memory operation in the profiled binary
+//     (i.e. load/store);
+//   - a delta (signed, base 10); and
+//   - the hint type (lower case string) - e.g. nta, t{0|1|2}.
+// The delta is to the next cache miss, calculated from the memory location
+// used in the memory operation at PC.
+PrefetchHints ReadPrefetchHints(const string &file_name) {
+  PrefetchHints hints;
+  FILE *fp = fopen(file_name.c_str(), "r");
+  if (fp == nullptr) {
+    LOG(ERROR) << "Cannot open " << file_name << "to read";
+  } else {
+    uint64 address = 0;
+    int64 delta = 0;
+    char prefetch_type[5];
+    while (!feof(fp)) {
+      if (3 != fscanf(fp, "%llx,%lld,%s\n", &address, &delta, prefetch_type)) {
+        LOG(ERROR) << "Error reading from " << file_name;
+        break;
+      }
+      // We don't validate the type here. We'll just use it as a suffix to the
+      // "__prefetch" indirect call, and let the compiler decide if it
+      // supports it.
+      string type(prefetch_type);
+      hints.push_back({address, delta, type});
+    }
+    fclose(fp);
+  }
+  return hints;
+}
+}  // namespace
 namespace autofdo {
 uint64 ProfileCreator::GetTotalCountFromTextProfile(
     const string &input_profile_name) {
@@ -38,17 +82,36 @@ uint64 ProfileCreator::GetTotalCountFromTextProfile(
   return creator.TotalSamples();
 }
 
+bool ProfileCreator::CheckAndAssignAddr2Line(SymbolMap *symbol_map,
+                                             Addr2line *addr2line) {
+  if (addr2line == nullptr) {
+    LOG(ERROR) << "Error reading binary " << binary_;
+    return false;
+  }
+  symbol_map->set_addr2line(std::unique_ptr<Addr2line>(addr2line));
+  return true;
+}
+
 bool ProfileCreator::CreateProfile(const string &input_profile_name,
                                    const string &profiler,
                                    ProfileWriter *writer,
                                    const string &output_profile_name) {
-  if (!ReadSample(input_profile_name, profiler)) {
-    return false;
+  SymbolMap symbol_map(binary_);
+  symbol_map.set_use_discriminator_encoding(use_discriminator_encoding_);
+  auto grouper =
+      ModuleGrouper::GroupModule(binary_, GCOV_ELF_SECTION_NAME, &symbol_map);
+
+  writer->setSymbolMap(&symbol_map);
+  writer->setModuleMap(&grouper->module_map());
+  if (profiler == "prefetch") {
+    symbol_map.set_ignore_thresholds(true);
+    if (!ConvertPrefetchHints(input_profile_name, &symbol_map)) return false;
+  } else {
+    if (!ReadSample(input_profile_name, profiler)) return false;
+    if (!ComputeProfile(&symbol_map)) return false;
   }
-  if (!CreateProfileFromSample(writer, output_profile_name)) {
-    return false;
-  }
-  return true;
+  bool ret = writer->WriteToFile(output_profile_name);
+  return ret;
 }
 
 bool ProfileCreator::ReadSample(const string &input_profile_name,
@@ -77,42 +140,61 @@ bool ProfileCreator::ReadSample(const string &input_profile_name,
   }
   return true;
 }
-
-bool ProfileCreator::ComputeProfile(SymbolMap *symbol_map,
-                                    Addr2line **addr2line) {
+bool ProfileCreator::ComputeProfile(SymbolMap *symbol_map) {
   std::set<uint64> sampled_addrs = sample_reader_->GetSampledAddresses();
   std::map<uint64, uint64> sampled_functions =
       symbol_map->GetSampledSymbolStartAddressSizeMap(sampled_addrs);
-  *addr2line =
-      Addr2line::CreateWithSampledFunctions(binary_, &sampled_functions);
-
-  if (*addr2line == nullptr) {
-    LOG(ERROR) << "Error reading binary " << binary_;
+  if (!CheckAndAssignAddr2Line(
+          symbol_map,
+          Addr2line::CreateWithSampledFunctions(binary_, &sampled_functions)))
     return false;
-  }
-
-  Profile profile(sample_reader_, binary_, *addr2line, symbol_map);
+  Profile profile(sample_reader_, binary_, symbol_map->get_addr2line(),
+                  symbol_map);
   profile.ComputeProfile();
 
   return true;
 }
 
-bool ProfileCreator::CreateProfileFromSample(ProfileWriter *writer,
-                                             const string &output_name) {
-  SymbolMap symbol_map(binary_);
-  symbol_map.set_use_discriminator_encoding(use_discriminator_encoding_);
-  Addr2line *addr2line = nullptr;
-  if (!ComputeProfile(&symbol_map, &addr2line)) return false;
+bool ProfileCreator::ConvertPrefetchHints(const string &profile_file,
+                                          SymbolMap *symbol_map) {
+  // Explicitly request constructing an Addr2line object with no sample profile
+  // data. Otherwise, passing an empty sample profile map would elide all
+  // addresses in the binary file, when the Google3Addr2line implementation is
+  // used.
+  if (!CheckAndAssignAddr2Line(symbol_map, Addr2line::Create(binary_)))
+    return false;
+  PrefetchHints hints = ReadPrefetchHints(profile_file);
+  std::map<uint64, uint8> repeated_prefetches_indices;
+  for (auto &hint : hints) {
+    uint64 pc = hint.address;
+    int64 delta = hint.delta;
+    const string *name = nullptr;
+    if (!symbol_map->GetSymbolInfoByAddr(pc, &name, nullptr, nullptr)) {
+      LOG(INFO) << "Instruction address not found:" << std::hex << pc;
+      continue;
+    }
+    uint8 prefetch_index = repeated_prefetches_indices[pc]++;
 
-  auto grouper =
-      ModuleGrouper::GroupModule(binary_, GCOV_ELF_SECTION_NAME, &symbol_map);
+    SourceStack stack;
+    symbol_map->get_addr2line()->GetInlineStack(pc, &stack);
 
-  writer->setSymbolMap(&symbol_map);
-  writer->setModuleMap(&grouper->module_map());
-  bool ret = writer->WriteToFile(output_name);
+    if (symbol_map->map().find(*name) == symbol_map->map().end()) {
+      symbol_map->AddSymbol(*name);
+      // Add bogus samples, so that the writer won't skip over.
+      symbol_map->TraverseInlineStack(*name, stack,
+                                      symbol_map->count_threshold() + 1);
+    }
 
-  delete addr2line;
-  return ret;
+    // Currently, the profile format expects unsigned values, corresponding to
+    // number of collected samples. We're hacking support for prefetch hints on
+    // top of that, and prefetch hints are signed. For now, we'll explicitly
+    // cast to unsigned.
+    symbol_map->AddIndirectCallTarget(
+        *name, stack,
+        "__prefetch_" + hint.type + "_" + std::to_string(prefetch_index),
+        static_cast<uint64>(delta));
+  }
+  return true;
 }
 
 uint64 ProfileCreator::TotalSamples() {

--- a/profile_creator.h
+++ b/profile_creator.h
@@ -65,10 +65,12 @@ class ProfileCreator {
 
   // Computes the profile and updates the given symbol map and addr2line
   // instance.
-  bool ComputeProfile(autofdo::SymbolMap *symbol_map,
-                      autofdo::Addr2line **addr2line);
+  bool ComputeProfile(SymbolMap *symbol_map);
 
  private:
+  bool ConvertPrefetchHints(const string &profile_file, SymbolMap *symbol_map);
+  bool CheckAndAssignAddr2Line(SymbolMap *symbol_map, Addr2line *addr2line);
+
   SampleReader *sample_reader_;
   string binary_;
   bool use_discriminator_encoding_;


### PR DESCRIPTION
Recommendations for locations to insert software cache prefetches are provided in a csv file as a triple `binary offset`,`delta`,`type`.

This is part of a larger system, consisting of a cache prefetches recommender, create_llvm_prof, and clang.

An example recommender is DynamoRIO's cache miss analyzer. It processes memory access traces obtained from a running binary and identifies patterns in cache misses. Based on them, it produces a csv file with recommendations. A recommendation is made in terms of: 

- the value of a memory operand of an instruction at a certain binary offset; 
- a delta; 
- and a type (nta, t0, t1, t2)

meaning: a prefetch of that type should be inserted right before the instrution at that binary offset, and the prefetch should be for an address delta away from the memory address the instruction will access. 

For example:

`0x400ab2,64,nta`

and assuming the instruction at 0x400ab2 is:

`movzbl (%rbx,%rdx,1),%edx`

means that the recommender determined it would be beneficial for a prefetchnta instruction to be inserted right before this instruction, as such:

```
prefetchnta 0x40(%rbx,%rdx,1)
movzbl (%rbx, %rdx, 1), %edx
```

See https://goo.gl/6TM2Xp for a script demonstrating this.

The workflow for prefetch cache instrumentation is as follows:

1. build binary.
2. collect memory traces, run analysis to obtain recommendations
3. convert recommendations to afdo using create_llvm_prof:

`create_llvm_prof --binary=<binary> --profile=<recommendations.csv> --profiler="prefetch" --out=<some_file.afdo> --format=<text or binary>`

4. rebuild binary, using the exact same set of arguments used initially, to which `-mllvm -prefetch-hints-file=<file>` needs to be added (the later is part of the upcoming LLVM change)

Note that if sample profiling feedback-driven optimization is desired, that happens before step 1 above. In this case, the sample profile afdo file that was used to produce the binary at step 1 must also be included in step 4.

The role of this change is to convert prefetching recommendations into data the compiler can use. This requires mapping the binary offsets to debug information. An upcoming LLVM change ensures each memory operand instruction is uniquely identified through debug info.

This is very similar to what needs to be done for sample profiles. For this reason, and given that the overall approach (memory tracing-based cache recommendation mechanisms) is under active development, we use the afdo format as a syntax for capturing this information. We avoid confusing semantics with sample profile afdo data by feeding the two types of information to the compiler through separate files and compiler flags.