### PR TITLE
Handle empty inlining stacks in create_llvm_prof

### DIFF
--- a/profile_creator.cc
+++ b/profile_creator.cc
@@ -16,17 +16,17 @@
 
 #include <memory>
 
-#include "addr2line.h"
-#include "base/common.h"
-#include "gcov.h"
-#include "gflags/gflags.h"
-#include "module_grouper.h"
-#include "profile.h"
 #include "profile_creator.h"
+#include "gflags/gflags.h"
+#include "base/common.h"
+#include "addr2line.h"
+#include "gcov.h"
+#include "profile.h"
 #include "profile_writer.h"
 #include "sample_reader.h"
 #include "symbol_map.h"
 #include "symbolize/elf_reader.h"
+#include "module_grouper.h"
 
 namespace {
 struct PrefetchHint {
@@ -126,8 +126,8 @@ bool ProfileCreator::ReadSample(const string &input_profile_name,
 
     ElfReader reader(binary_);
 
-    sample_reader_ =
-        new PerfDataSampleReader(input_profile_name, std::move(file_base_name));
+    sample_reader_ = new PerfDataSampleReader(
+        input_profile_name, std::move(file_base_name));
   } else if (profiler == "text") {
     sample_reader_ = new TextSampleReaderWriter(input_profile_name);
   } else {

--- a/profile_creator.cc
+++ b/profile_creator.cc
@@ -16,17 +16,17 @@
 
 #include <memory>
 
-#include "profile_creator.h"
-#include "gflags/gflags.h"
-#include "base/common.h"
 #include "addr2line.h"
+#include "base/common.h"
 #include "gcov.h"
+#include "gflags/gflags.h"
+#include "module_grouper.h"
 #include "profile.h"
+#include "profile_creator.h"
 #include "profile_writer.h"
 #include "sample_reader.h"
 #include "symbol_map.h"
 #include "symbolize/elf_reader.h"
-#include "module_grouper.h"
 
 namespace {
 struct PrefetchHint {
@@ -126,8 +126,8 @@ bool ProfileCreator::ReadSample(const string &input_profile_name,
 
     ElfReader reader(binary_);
 
-    sample_reader_ = new PerfDataSampleReader(
-        input_profile_name, std::move(file_base_name));
+    sample_reader_ =
+        new PerfDataSampleReader(input_profile_name, std::move(file_base_name));
   } else if (profiler == "text") {
     sample_reader_ = new TextSampleReaderWriter(input_profile_name);
   } else {
@@ -181,18 +181,26 @@ bool ProfileCreator::ConvertPrefetchHints(const string &profile_file,
     if (symbol_map->map().find(*name) == symbol_map->map().end()) {
       symbol_map->AddSymbol(*name);
       // Add bogus samples, so that the writer won't skip over.
-      symbol_map->TraverseInlineStack(*name, stack,
-                                      symbol_map->count_threshold() + 1);
+      if (!symbol_map->TraverseInlineStack(*name, stack,
+                                           symbol_map->count_threshold() + 1)) {
+        LOG(WARNING) << "Ignoring address " << std::hex << pc
+                     << ". No inline stack found.";
+        continue;
+      }
     }
 
     // Currently, the profile format expects unsigned values, corresponding to
     // number of collected samples. We're hacking support for prefetch hints on
     // top of that, and prefetch hints are signed. For now, we'll explicitly
     // cast to unsigned.
-    symbol_map->AddIndirectCallTarget(
-        *name, stack,
-        "__prefetch_" + hint.type + "_" + std::to_string(prefetch_index),
-        static_cast<uint64>(delta));
+    if (!symbol_map->AddIndirectCallTarget(
+            *name, stack,
+            "__prefetch_" + hint.type + "_" + std::to_string(prefetch_index),
+            static_cast<uint64>(delta))) {
+      LOG(WARNING) << "Ignoring address " << std::hex << pc
+                   << ". Could not add an indirect call target. Likely the "
+                      "inline stack is empty for this address.";
+    }
   }
   return true;
 }

--- a/symbol_map.cc
+++ b/symbol_map.cc
@@ -18,9 +18,9 @@
 #include <map>
 #include <set>
 
-#include "addr2line.h"
-#include "base/common.h"
 #include "gflags/gflags.h"
+#include "base/common.h"
+#include "addr2line.h"
 #include "symbol_map.h"
 #include "symbolize/elf_reader.h"
 
@@ -33,7 +33,8 @@ DEFINE_double(sample_threshold_frac, 0.000005,
 
 namespace {
 // Returns whether str ends with suffix.
-inline bool HasSuffixString(const string &str, const string &suffix) {
+inline bool HasSuffixString(const string &str,
+                            const string &suffix) {
   uint32 len = suffix.size();
   uint32 str_len = str.size();
   if (str_len <= len) {
@@ -69,7 +70,7 @@ void PrintSourceLocation(uint32 start_line, uint32 offset, int ident) {
 }  // namespace
 
 namespace autofdo {
-ProfileInfo &ProfileInfo::operator+=(const ProfileInfo &s) {
+ProfileInfo& ProfileInfo::operator+=(const ProfileInfo &s) {
   count += s.count;
   num_inst += s.num_inst;
   for (const auto &target_count : s.target_map) {
@@ -101,8 +102,8 @@ SymbolMap::~SymbolMap() {
   // In order to prevent double free, we first merge all symbols
   // into a set, then remove every symbol from the set.
   set<Symbol *> delete_set;
-  for (NameSymbolMap::iterator iter = map_.begin(); iter != map_.end();
-       ++iter) {
+  for (NameSymbolMap::iterator iter = map_.begin();
+       iter != map_.end(); ++iter) {
     delete_set.insert(iter->second);
   }
   for (const auto &symbol : delete_set) {
@@ -120,15 +121,15 @@ void Symbol::Merge(const Symbol *other) {
   total_count += other->total_count;
   head_count += other->head_count;
   if (info.file_name == NULL) {
-    info.file_name = other->info.file_name;
-    info.dir_name = other->info.dir_name;
+      info.file_name = other->info.file_name;
+      info.dir_name = other->info.dir_name;
   }
   for (const auto &pos_count : other->pos_counts)
     pos_counts[pos_count.first] += pos_count.second;
   // Traverses all callsite, recursively Merge the callee symbol.
   for (const auto &callsite_symbol : other->callsites) {
-    std::pair<CallsiteMap::iterator, bool> ret =
-        callsites.insert(CallsiteMap::value_type(callsite_symbol.first, NULL));
+    std::pair<CallsiteMap::iterator, bool> ret = callsites.insert(
+        CallsiteMap::value_type(callsite_symbol.first, NULL));
     // If the callsite does not exist in the current symbol, create a
     // new callee symbol with the clone's function name.
     if (ret.second) {
@@ -144,8 +145,9 @@ void SymbolMap::Merge() {
     string name = GetOriginalName(name_symbol.first.c_str());
     std::pair<NameSymbolMap::iterator, bool> ret =
         map_.insert(NameSymbolMap::value_type(name, NULL));
-    if (ret.second || (name_symbol.first != name &&
-                       name_symbol.second == ret.first->second)) {
+    if (ret.second ||
+        (name_symbol.first != name &&
+         name_symbol.second == ret.first->second)) {
       ret.first->second = new Symbol();
       ret.first->second->info.func_name = ret.first->first.c_str();
     }
@@ -164,8 +166,8 @@ void SymbolMap::Merge() {
 }
 
 void SymbolMap::AddSymbol(const string &name) {
-  std::pair<NameSymbolMap::iterator, bool> ret =
-      map_.insert(NameSymbolMap::value_type(name, NULL));
+  std::pair<NameSymbolMap::iterator, bool> ret = map_.insert(
+      NameSymbolMap::value_type(name, NULL));
   if (ret.second) {
     ret.first->second = new Symbol(ret.first->first.c_str(), NULL, NULL, 0);
     NameAliasMap::const_iterator alias_iter = name_alias_map_.find(name);
@@ -203,9 +205,9 @@ void SymbolMap::CalculateThreshold() {
   }
 }
 
-const bool SymbolMap::GetSymbolInfoByAddr(uint64 addr, const string **name,
-                                          uint64 *start_addr,
-                                          uint64 *end_addr) const {
+const bool SymbolMap::GetSymbolInfoByAddr(
+    uint64 addr, const string **name,
+    uint64 *start_addr, uint64 *end_addr) const {
   AddressSymbolMap::const_iterator ret = address_symbol_map_.upper_bound(addr);
   if (ret == address_symbol_map_.begin()) {
     return false;
@@ -240,7 +242,7 @@ class SymbolReader : public ElfReader::SymbolSink {
   explicit SymbolReader(NameAliasMap *name_alias_map,
                         AddressSymbolMap *address_symbol_map)
       : name_alias_map_(name_alias_map),
-        address_symbol_map_(address_symbol_map) {}
+        address_symbol_map_(address_symbol_map) { }
   virtual void AddSymbol(const char *name, uint64 address, uint64 size) {
     if (size == 0) {
       return;
@@ -252,7 +254,7 @@ class SymbolReader : public ElfReader::SymbolSink {
       (*name_alias_map_)[ret.first->second.first].insert(name);
     }
   }
-  virtual ~SymbolReader() {}
+  virtual ~SymbolReader() { }
 
  private:
   NameAliasMap *name_alias_map_;
@@ -260,6 +262,7 @@ class SymbolReader : public ElfReader::SymbolSink {
 
   DISALLOW_COPY_AND_ASSIGN(SymbolReader);
 };
+
 
 void SymbolMap::BuildSymbolMap() {
   ElfReader elf_reader(binary_);
@@ -322,7 +325,8 @@ void SymbolMap::AddSymbolEntryCount(const string &symbol_name, uint64 count) {
 }
 
 Symbol *SymbolMap::TraverseInlineStack(const string &symbol_name,
-                                       const SourceStack &src, uint64 count) {
+                                       const SourceStack &src,
+                                       uint64 count) {
   if (src.empty()) return nullptr;
   Symbol *symbol = map_.find(symbol_name)->second;
   symbol->total_count += count;
@@ -338,9 +342,10 @@ Symbol *SymbolMap::TraverseInlineStack(const string &symbol_name,
                      src[i - 1].func_name),
             NULL));
     if (ret.second) {
-      ret.first->second =
-          new Symbol(src[i - 1].func_name, src[i - 1].dir_name,
-                     src[i - 1].file_name, src[i - 1].start_line);
+      ret.first->second = new Symbol(src[i - 1].func_name,
+                                     src[i - 1].dir_name,
+                                     src[i - 1].file_name,
+                                     src[i - 1].start_line);
     }
     symbol = ret.first->second;
     symbol->total_count += count;
@@ -349,8 +354,9 @@ Symbol *SymbolMap::TraverseInlineStack(const string &symbol_name,
 }
 
 void SymbolMap::AddSourceCount(const string &symbol_name,
-                               const SourceStack &src, uint64 count,
-                               uint64 num_inst, Operation op) {
+                               const SourceStack &src,
+                               uint64 count, uint64 num_inst,
+                               Operation op) {
   Symbol *symbol = TraverseInlineStack(symbol_name, src, count);
   if (!symbol) return;
 
@@ -369,32 +375,36 @@ void SymbolMap::AddSourceCount(const string &symbol_name,
 
 bool SymbolMap::AddIndirectCallTarget(const string &symbol_name,
                                       const SourceStack &src,
-                                      const string &target, uint64 count) {
+                                      const string &target,
+                                      uint64 count) {
   Symbol *symbol = TraverseInlineStack(symbol_name, src, 0);
 
   if (!symbol) return false;
-  symbol->pos_counts[src[0].Offset(use_discriminator_encoding_)]
-      .target_map[GetOriginalName(target.c_str())] = count;
+  symbol->pos_counts[src[0].Offset(use_discriminator_encoding_)].target_map[
+      GetOriginalName(target.c_str())] = count;
   return true;
 }
 
 struct CallsiteLessThan {
-  bool operator()(const Callsite &c1, const Callsite &c2) const {
-    if (c1.first != c2.first) return c1.first < c2.first;
-    if ((c1.second == NULL || c2.second == NULL)) return c1.second == NULL;
+  bool operator()(const Callsite& c1, const Callsite& c2) const {
+    if (c1.first != c2.first)
+      return c1.first < c2.first;
+    if ((c1.second == NULL || c2.second == NULL))
+      return c1.second == NULL;
     return strcmp(c1.second, c2.second) < 0;
   }
 };
 
 void Symbol::Dump(int ident) const {
   if (ident == 0) {
-    printf("%s total:%llu head:%llu\n", info.func_name, total_count,
-           head_count);
+    printf("%s total:%llu head:%llu\n", info.func_name,
+           total_count, head_count);
   } else {
     printf("%s total:%llu\n", info.func_name, total_count);
   }
   std::vector<uint32> positions;
-  for (const auto &pos_count : pos_counts) positions.push_back(pos_count.first);
+  for (const auto &pos_count : pos_counts)
+    positions.push_back(pos_count.first);
   std::sort(positions.begin(), positions.end());
   for (const auto &pos : positions) {
     PositionCountMap::const_iterator ret = pos_counts.find(pos);
@@ -402,7 +412,8 @@ void Symbol::Dump(int ident) const {
     PrintSourceLocation(info.start_line, pos, ident + 2);
     printf("%llu", ret->second.count);
     TargetCountPairs target_count_pairs;
-    GetSortedTargetCountPairs(ret->second.target_map, &target_count_pairs);
+    GetSortedTargetCountPairs(ret->second.target_map,
+                              &target_count_pairs);
     for (const auto &target_count : target_count_pairs) {
       printf("  %s:%llu", target_count.first.c_str(), target_count.second);
     }
@@ -422,11 +433,11 @@ void Symbol::Dump(int ident) const {
 uint64 Symbol::MaxPosCallsiteCount() const {
   uint64 max_count = 0;
 
-  for (const auto &pos_count : pos_counts) {
+  for (const auto& pos_count : pos_counts) {
     max_count = std::max(max_count, pos_count.second.count);
   }
 
-  for (const auto &callsite : callsites) {
+  for (const auto& callsite : callsites) {
     max_count = std::max(max_count, callsite.second->MaxPosCallsiteCount());
   }
 
@@ -475,9 +486,9 @@ float SymbolMap::Overlap(const SymbolMap &map) const {
   // Calculate the overlap
   float overlap = 0.0;
   for (const auto &name_counts : overlap_map) {
-    overlap +=
-        std::min(static_cast<float>(name_counts.second.first) / total_1,
-                 static_cast<float>(name_counts.second.second) / total_2);
+    overlap += std::min(
+        static_cast<float>(name_counts.second.first) / total_1,
+        static_cast<float>(name_counts.second.second) / total_2);
   }
   return overlap;
 }
@@ -518,7 +529,8 @@ void SymbolMap::DumpFuncLevelProfileCompare(const SymbolMap &map) const {
       }
       printf("%3.4f%% %3.4f%% %s\n",
              100 * static_cast<double>(symbol->total_count) / max_1,
-             100 * static_cast<double>(compare_count) / max_2, name.c_str());
+             100 * static_cast<double>(compare_count) / max_2,
+             name.c_str());
     }
   }
 
@@ -567,8 +579,8 @@ static uint64 AddSymbolProfileToHistogram(const Symbol *symbol,
     total_count += pos_count.second.count * pos_count.second.num_inst;
   }
   for (const auto &callsite_symbol : symbol->callsites) {
-    total_count +=
-        AddSymbolProfileToHistogram(callsite_symbol.second, histogram);
+    total_count += AddSymbolProfileToHistogram(callsite_symbol.second,
+                                               histogram);
   }
   return total_count;
 }
@@ -591,9 +603,9 @@ void SymbolMap::ComputeWorkingSets() {
        iter != histogram.rend() && bucket_num < NUM_GCOV_WORKING_SETS; ++iter) {
     uint64 count = iter->first;
     uint64 num_inst = iter->second;
-    while (count * num_inst + accumulated_count >
-               one_bucket_count * (bucket_num + 1) &&
-           bucket_num < NUM_GCOV_WORKING_SETS) {
+    while (count * num_inst + accumulated_count
+           > one_bucket_count * (bucket_num + 1)
+           && bucket_num < NUM_GCOV_WORKING_SETS) {
       int64 offset =
           (one_bucket_count * (bucket_num + 1) - accumulated_count) / count;
       accumulated_inst += offset;
@@ -633,8 +645,8 @@ std::map<uint64, uint64> SymbolMap::GetSampledSymbolStartAddressSizeMap(
       continue;
     }
     const auto &iter = map_.find(addr_symbol.second.first);
-    if (iter != map_.end() && iter->second != NULL &&
-        iter->second->total_count > 0) {
+    if (iter != map_.end() && iter->second != NULL
+        && iter->second->total_count > 0) {
       ret[addr_symbol.first] = addr_symbol.second.second;
     }
   }
@@ -680,7 +692,7 @@ std::map<uint64, uint64> SymbolMap::GetLegacySymbolStartAddressSizeMap() const {
   return ret;
 }
 
-void SymbolMap::AddAlias(const string &sym, const string &alias) {
+void SymbolMap::AddAlias(const string& sym, const string& alias) {
   name_alias_map_[sym].insert(alias);
 }
 
@@ -745,7 +757,8 @@ bool SymbolMap::Validate() const {
   }
   if (num_srcs_non_zero < num_srcs * kMinNonZeroSrcFrac) {
     LOG(ERROR) << "Do not have enough non-zero src locations."
-               << " NonZero: " << num_srcs_non_zero << " Total: " << num_srcs;
+               << " NonZero: " << num_srcs_non_zero
+               << " Total: " << num_srcs;
     return false;
   }
   return true;

--- a/symbol_map.h
+++ b/symbol_map.h
@@ -83,9 +83,11 @@ typedef std::map<uint32, ProfileInfo> PositionCountMap;
 typedef std::pair<uint32, const char *> Callsite;
 
 struct CallsiteLess {
-  bool operator()(const Callsite &c1, const Callsite &c2) const {
-    if (c1.first != c2.first) return c1.first < c2.first;
-    if ((c1.second == NULL || c2.second == NULL)) return c1.second < c2.second;
+  bool operator()(const Callsite& c1, const Callsite& c2) const {
+    if (c1.first != c2.first)
+      return c1.first < c2.first;
+    if ((c1.second == NULL || c2.second == NULL))
+      return c1.second < c2.second;
     return strcmp(c1.second, c2.second) < 0;
   }
 };
@@ -106,13 +108,11 @@ class Symbol {
   // This constructor is used to create inlined symbol.
   Symbol(const char *name, const char *dir, const char *file, uint32 start)
       : info(SourceInfo(name, dir, file, start, 0, 0)),
-        total_count(0),
-        head_count(0) {}
+        total_count(0), head_count(0) {}
 
   // This constructor is used to create aliased symbol.
   Symbol(const Symbol *src, const char *new_func_name)
-      : info(src->info),
-        total_count(src->total_count),
+      : info(src->info), total_count(src->total_count),
         head_count(src->head_count) {
     info.func_name = new_func_name;
   }
@@ -125,7 +125,9 @@ class Symbol {
     return (name && strlen(name) > 0) ? name : "noname";
   }
 
-  string name() const { return Name(info.func_name); }
+  string name() const {
+    return Name(info.func_name);
+  }
 
   // Merges profile stored in src symbol with this symbol.
   void Merge(const Symbol *src);
@@ -187,10 +189,12 @@ class SymbolMap {
 
   ~SymbolMap();
 
-  uint64 size() const { return map_.size(); }
+  uint64 size() const {
+    return map_.size();
+  }
 
-  void set_count_threshold(int64 n) { count_threshold_ = n; }
-  int64 count_threshold() const { return count_threshold_; }
+  void set_count_threshold(int64 n) {count_threshold_ = n;}
+  int64 count_threshold() const {return count_threshold_;}
 
   // Returns true if the count is large enough to be emitted.
   bool ShouldEmit(int64 count) const {
@@ -207,13 +211,17 @@ class SymbolMap {
   void CalculateThreshold();
 
   // Returns relocation start address.
-  uint64 base_addr() const { return base_addr_; }
+  uint64 base_addr() const {
+    return base_addr_;
+  }
 
   void set_use_discriminator_encoding(bool v) {
     use_discriminator_encoding_ = v;
   }
 
-  void set_ignore_thresholds(bool v) { ignore_thresholds_ = v; }
+  void set_ignore_thresholds(bool v) {
+    ignore_thresholds_ = v;
+  }
 
   void set_addr2line(std::unique_ptr<Addr2line> addr2line) {
     addr2line_ = std::move(addr2line);
@@ -224,11 +232,17 @@ class SymbolMap {
   // Adds an empty named symbol.
   void AddSymbol(const string &name);
 
-  const NameSymbolMap &map() const { return map_; }
+  const NameSymbolMap &map() const {
+    return map_;
+  }
 
-  NameSymbolMap &map() { return map_; }
+  NameSymbolMap &map() {
+    return map_;
+  }
 
-  const gcov_working_set_info *GetWorkingSets() const { return working_set_; }
+  const gcov_working_set_info *GetWorkingSets() const {
+    return working_set_;
+  }
 
   uint64 GetSymbolStartAddr(const string &name) const {
     const auto &iter = name_addr_map_.find(name);
@@ -266,7 +280,7 @@ class SymbolMap {
   // Increments symbol's entry count.
   void AddSymbolEntryCount(const string &symbol, uint64 count);
 
-  typedef enum { INVALID = 1, SUM, MAX } Operation;
+  typedef enum {INVALID = 1, SUM, MAX} Operation;
   // Increments source stack's count.
   //   symbol: name of the symbol in which source is located.
   //   source: source location (in terms of inlined source stack).
@@ -344,7 +358,7 @@ class SymbolMap {
   void Dump() const;
   void DumpFuncLevelProfileCompare(const SymbolMap &map) const;
 
-  void AddAlias(const string &sym, const string &alias);
+  void AddAlias(const string& sym, const string& alias);
 
   // Validates if the current symbol map is sane.
   bool Validate() const;

--- a/symbol_map.h
+++ b/symbol_map.h
@@ -83,11 +83,9 @@ typedef std::map<uint32, ProfileInfo> PositionCountMap;
 typedef std::pair<uint32, const char *> Callsite;
 
 struct CallsiteLess {
-  bool operator()(const Callsite& c1, const Callsite& c2) const {
-    if (c1.first != c2.first)
-      return c1.first < c2.first;
-    if ((c1.second == NULL || c2.second == NULL))
-      return c1.second < c2.second;
+  bool operator()(const Callsite &c1, const Callsite &c2) const {
+    if (c1.first != c2.first) return c1.first < c2.first;
+    if ((c1.second == NULL || c2.second == NULL)) return c1.second < c2.second;
     return strcmp(c1.second, c2.second) < 0;
   }
 };
@@ -108,11 +106,13 @@ class Symbol {
   // This constructor is used to create inlined symbol.
   Symbol(const char *name, const char *dir, const char *file, uint32 start)
       : info(SourceInfo(name, dir, file, start, 0, 0)),
-        total_count(0), head_count(0) {}
+        total_count(0),
+        head_count(0) {}
 
   // This constructor is used to create aliased symbol.
   Symbol(const Symbol *src, const char *new_func_name)
-      : info(src->info), total_count(src->total_count),
+      : info(src->info),
+        total_count(src->total_count),
         head_count(src->head_count) {
     info.func_name = new_func_name;
   }
@@ -125,9 +125,7 @@ class Symbol {
     return (name && strlen(name) > 0) ? name : "noname";
   }
 
-  string name() const {
-    return Name(info.func_name);
-  }
+  string name() const { return Name(info.func_name); }
 
   // Merges profile stored in src symbol with this symbol.
   void Merge(const Symbol *src);
@@ -189,12 +187,10 @@ class SymbolMap {
 
   ~SymbolMap();
 
-  uint64 size() const {
-    return map_.size();
-  }
+  uint64 size() const { return map_.size(); }
 
-  void set_count_threshold(int64 n) {count_threshold_ = n;}
-  int64 count_threshold() const {return count_threshold_;}
+  void set_count_threshold(int64 n) { count_threshold_ = n; }
+  int64 count_threshold() const { return count_threshold_; }
 
   // Returns true if the count is large enough to be emitted.
   bool ShouldEmit(int64 count) const {
@@ -211,17 +207,13 @@ class SymbolMap {
   void CalculateThreshold();
 
   // Returns relocation start address.
-  uint64 base_addr() const {
-    return base_addr_;
-  }
+  uint64 base_addr() const { return base_addr_; }
 
   void set_use_discriminator_encoding(bool v) {
     use_discriminator_encoding_ = v;
   }
 
-  void set_ignore_thresholds(bool v) {
-    ignore_thresholds_ = v;
-  }
+  void set_ignore_thresholds(bool v) { ignore_thresholds_ = v; }
 
   void set_addr2line(std::unique_ptr<Addr2line> addr2line) {
     addr2line_ = std::move(addr2line);
@@ -232,17 +224,11 @@ class SymbolMap {
   // Adds an empty named symbol.
   void AddSymbol(const string &name);
 
-  const NameSymbolMap &map() const {
-    return map_;
-  }
+  const NameSymbolMap &map() const { return map_; }
 
-  NameSymbolMap &map() {
-    return map_;
-  }
+  NameSymbolMap &map() { return map_; }
 
-  const gcov_working_set_info *GetWorkingSets() const {
-    return working_set_;
-  }
+  const gcov_working_set_info *GetWorkingSets() const { return working_set_; }
 
   uint64 GetSymbolStartAddr(const string &name) const {
     const auto &iter = name_addr_map_.find(name);
@@ -280,7 +266,7 @@ class SymbolMap {
   // Increments symbol's entry count.
   void AddSymbolEntryCount(const string &symbol, uint64 count);
 
-  typedef enum {INVALID = 1, SUM, MAX} Operation;
+  typedef enum { INVALID = 1, SUM, MAX } Operation;
   // Increments source stack's count.
   //   symbol: name of the symbol in which source is located.
   //   source: source location (in terms of inlined source stack).
@@ -295,11 +281,13 @@ class SymbolMap {
   //   source: source location (in terms of inlined source stack).
   //   target: indirect call target.
   //   count: total sampled count.
-  void AddIndirectCallTarget(const string &symbol, const SourceStack &source,
+  // Returns false if we failed to add the call target.
+  bool AddIndirectCallTarget(const string &symbol, const SourceStack &source,
                              const string &target, uint64 count);
 
   // Traverses the inline stack in source, update the symbol map by adding
-  // count to the total count in the inlined symbol. Returns the leaf symbol.
+  // count to the total count in the inlined symbol. Returns the leaf symbol. If
+  // the inline stack is empty, returns nullptr without any other updates.
   Symbol *TraverseInlineStack(const string &symbol, const SourceStack &source,
                               uint64 count);
 
@@ -356,7 +344,7 @@ class SymbolMap {
   void Dump() const;
   void DumpFuncLevelProfileCompare(const SymbolMap &map) const;
 
-  void AddAlias(const string& sym, const string& alias);
+  void AddAlias(const string &sym, const string &alias);
 
   // Validates if the current symbol map is sane.
   bool Validate() const;


### PR DESCRIPTION
This might validly happen in cases where the binary offset corresponds to a .S file (for example).