### PR TITLE
Add ignore_thresholds_ to SymbolMap constructor initializer list

### DIFF
--- a/symbol_map.h
+++ b/symbol_map.h
@@ -185,7 +185,8 @@ class SymbolMap {
   SymbolMap()
       : base_addr_(0),
         count_threshold_(0),
-        use_discriminator_encoding_(false) {}
+        use_discriminator_encoding_(false),
+        ignore_thresholds_(false) {}
 
   ~SymbolMap();
 


### PR DESCRIPTION
simple fix to SymbolMap() constructor initializer list