### PR TITLE
[README] Recommend installing libtool

### DIFF
--- a/README
+++ b/README
@@ -8,7 +8,7 @@ line flags. However, the outputs are incompatible. You cannot
 use the profile generated for GCC in LLVM and vice-versa.
 
 Install dependencies:
-	sudo apt-get -y install autoconf automake git libelf-dev libssl-dev pkg-config
+	sudo apt-get -y install autoconf automake git libelf-dev libssl-dev libtool pkg-config
 
 Clone the repository using the following command:
 	git clone --recursive https://github.com/google/autofdo.git


### PR DESCRIPTION
When attempting to build the project on trunk, I encountered the same issues reported in #74. Specifically:

```
configure.ac:30: error: possibly undefined macro: AC_PROG_LIBTOOL
```

Running `apt-get install libtool` solved the issue for me, so mention this as an install dependency in the README.