### PR TITLE
Add libtool to the dependencies

### DIFF
--- a/README
+++ b/README
@@ -8,7 +8,7 @@ line flags. However, the outputs are incompatible. You cannot
 use the profile generated for GCC in LLVM and vice-versa.
 
 Install dependencies:
-	sudo apt-get -y install autoconf automake git libelf-dev libssl-dev pkg-config
+	sudo apt-get -y install autoconf automake git libelf-dev libssl-dev pkg-config libtool
 
 Clone the repository using the following command:
 	git clone --recursive https://github.com/google/autofdo.git


### PR DESCRIPTION
Installing `libtool` is required. 
The following error is produced if this dependency is missing:
```
configure.ac:30: error: possibly undefined macro: AC_PROG_LIBTOOL
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
autoreconf: /usr/bin/autoconf failed with exit status: 1
```