### PR TITLE
Fix build error for LLVM11

### DIFF
--- a/llvm_profile_writer.cc
+++ b/llvm_profile_writer.cc
@@ -94,8 +94,7 @@ void LLVMProfileBuilder::VisitCallsite(const Callsite &callsite) {
     inline_stack_.pop_back();
   }
   auto &caller_profile = *(inline_stack_.back());
-  auto CalleeName = 
-    std::__cxx11::basic_string<char>(GetNameRef(Symbol::Name(callsite.second)).str());
+  auto CalleeName = GetNameRef(Symbol::Name(callsite.second)).str();
   auto &callee_profile =
       caller_profile.functionSamplesAt(llvm::sampleprof::LineLocation(
           line, discriminator))[CalleeName];

--- a/llvm_profile_writer.cc
+++ b/llvm_profile_writer.cc
@@ -94,7 +94,8 @@ void LLVMProfileBuilder::VisitCallsite(const Callsite &callsite) {
     inline_stack_.pop_back();
   }
   auto &caller_profile = *(inline_stack_.back());
-  auto CalleeName = GetNameRef(Symbol::Name(callsite.second));
+  auto CalleeName = 
+    std::__cxx11::basic_string<char>(GetNameRef(Symbol::Name(callsite.second)).str());
   auto &callee_profile =
       caller_profile.functionSamplesAt(llvm::sampleprof::LineLocation(
           line, discriminator))[CalleeName];


### PR DESCRIPTION
This commit fixes build error for LLVM11 (https://github.com/google/autofdo/issues/87) by explicitly converting from a `llvm::StringRef` object to a `__cxx11::std::basic_string<char>` object to satisfy the `std::map` `[]` operator.

<br>

**UPDATE:** CLA signed.