### PR TITLE
Add "libtool" to build dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ use the profile generated for GCC in LLVM and vice-versa.
 # Prerequisites to Build:
 Install dependencies:
 ```
-sudo apt-get -y install autoconf automake git libelf-dev libssl-dev pkg-config
+sudo apt-get -y install libtool autoconf automake git libelf-dev libssl-dev pkg-config
 ```
 
 # Clone & Compile


### PR DESCRIPTION
Our intern twice reported errors while setting up new machines for building autofdo.

ranlib libgflags.a
configure.ac:30: error: possibly undefined macro: AC_PROG_LIBTOOL
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
autoreconf: /usr/bin/autoconf failed with exit status: 1

This was fixed by apt-get install libtool.