### PR TITLE
Update perf_data_converter to be on latest commit

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -15,13 +15,16 @@ $(PROTOC) $(PROTOBUF)/src/.libs/libprotobuf.a: $(PROTOBUF)/configure
 
 protoc_inputs = \
 	third_party/perf_data_converter/src/quipper/perf_data.proto \
-	third_party/perf_data_converter/src/quipper/perf_stat.proto
+	third_party/perf_data_converter/src/quipper/perf_stat.proto \
+	third_party/perf_data_converter/src/quipper/perf_parser_options.proto
 
 protoc_outputs = \
 	third_party/perf_data_converter/src/quipper/perf_data.pb.cc \
 	third_party/perf_data_converter/src/quipper/perf_data.pb.h \
 	third_party/perf_data_converter/src/quipper/perf_stat.pb.cc \
-	third_party/perf_data_converter/src/quipper/perf_stat.pb.h
+	third_party/perf_data_converter/src/quipper/perf_stat.pb.h  \
+	third_party/perf_data_converter/src/quipper/perf_parser_options.pb.cc \
+	third_party/perf_data_converter/src/quipper/perf_parser_options.pb.h
 
 $(protoc_outputs): $(protoc_inputs) $(PROTOC)
 	$(PROTOC) --cpp_out=`dirname $<` -I`dirname $<` $(protoc_inputs)

--- a/sample_reader.cc
+++ b/sample_reader.cc
@@ -212,7 +212,7 @@ bool PerfDataSampleReader::Append(const string &profile_file) {
   // focus_binary_re_ is used to match the binary name with the samples.
   for (const auto &event : parser.parsed_events()) {
     if (!event.event_ptr ||
-        event.event_ptr->header().type() != PERF_RECORD_SAMPLE) {
+        event.event_ptr->header().type() != quipper::PERF_RECORD_SAMPLE) {
       continue;
     }
     if (MatchBinary(event.dso_and_offset.dso_name(), focus_binary)) {


### PR DESCRIPTION
Some of the coresight support work may require changes to the
quipper library so having an up to date quipper submodule will
help with this

Change-Id: I20ad8064a2f2beb5ac01c7b08bf5fe7951780e42