### PR TITLE
Make AutoFDO create_gcov respect --debug_dump

### DIFF
--- a/profile_writer.cc
+++ b/profile_writer.cc
@@ -202,6 +202,8 @@ void AutoFDOProfileWriter::WriteWorkingSet() {
 }
 
 bool AutoFDOProfileWriter::WriteToFile(const std::string &output_filename) {
+  if (absl::GetFlag(FLAGS_debug_dump)) Dump();
+
   if (!WriteHeader(output_filename)) {
     return false;
   }


### PR DESCRIPTION
The change to AutoFDOProfileWriter::WriteToFile is similar
to the existing code in LLVMProfileWriter::WriteToFile.