### PR TITLE
Rearrange if conditions so mandatory Expected<T> check is not short-circuited

### DIFF
--- a/llvm_propeller_whole_program_info.cc
+++ b/llvm_propeller_whole_program_info.cc
@@ -87,8 +87,8 @@ llvm::Optional<llvm::object::SectionRef> FindBbAddrMapSection(
     Expected<llvm::StringRef> sn = sec.getName();
     llvm::object::ELFSectionRef esec(sec);
 #if LLVM_VERSION_MAJOR >= 12
-    if (esec.getType() == llvm::ELF::SHT_LLVM_BB_ADDR_MAP &&
-        sn && (*sn) == PropellerWholeProgramInfo::kBbAddrMapSectionName)
+    if (sn && esec.getType() == llvm::ELF::SHT_LLVM_BB_ADDR_MAP &&
+	(*sn) == PropellerWholeProgramInfo::kBbAddrMapSectionName)
 #else
     if (sn && (*sn) == PropellerWholeProgramInfo::kBbAddrMapSectionName)
 #endif

--- a/perfdata_reader.cc
+++ b/perfdata_reader.cc
@@ -68,7 +68,7 @@ class ELFFileUtil : public ELFFileUtilBase {
 #else
           elf_file_->getSectionName(&shdr);
 #endif
-      if (shdr.sh_type != llvm::ELF::SHT_NOTE || !section_name ||
+      if (!section_name || shdr.sh_type != llvm::ELF::SHT_NOTE ||
           *section_name != kBuildIDSectionName)
         continue;
       llvm::Error err = llvm::Error::success();


### PR DESCRIPTION
Rearrange if conditions so mandatory Expected<T> check is not short-circuited

This fixed bug for issue/119.
