### PR TITLE
Fix dump_gcov

### DIFF
--- a/profile_reader.cc
+++ b/profile_reader.cc
@@ -111,8 +111,7 @@ bool AutoFDOProfileReader::ReadFromFile(const std::string &output_file) {
 
   // Read tags
   CHECK_EQ(gcov_read_unsigned(), GCOV_DATA_MAGIC) << output_file;
-  CHECK_EQ(gcov_read_unsigned(), absl::GetFlag(FLAGS_gcov_version))
-      << output_file;
+  absl::SetFlag(&FLAGS_gcov_version, gcov_read_unsigned());
   gcov_read_unsigned();
 
   ReadNameTable();


### PR DESCRIPTION
Currently an invocation like

dump_gcov ./sort.gcda

 fails with

F20210903 16:42:21.612994 2065129 profile_reader.cc:114] Check failed: gcov_read_unsigned() == absl::GetFlag(FLAGS_gcov_version) (2 vs. 875575082) ./sort.gcda
*** Check failure stack trace: ***
Aborted (core dumped)

There is no way to pass the version to dump_gcov and it makes more sense to just use
the version encoded in the file.