### PR TITLE
Fix the broken url link in propeller optimization guide.

### DIFF
--- a/docs/OptimizeClangO3WithPropeller.md
+++ b/docs/OptimizeClangO3WithPropeller.md
@@ -20,7 +20,7 @@ There are essentially four steps to optimize any binary with Propeller:
 
 In the following sections, we will show how to go about doing each step in
 detail. We have uploaded the script to do all the steps mentioned below
-[here.](propeller_optimize_clang.sh)
+[here.](../propeller_optimize_clang.sh)
 
 ## Build Trunk LLVM
 

--- a/propeller_optimize_clang.sh
+++ b/propeller_optimize_clang.sh
@@ -17,7 +17,7 @@
 set -eu
 
 # Set this path and run the script.
-BASE_PROPELLER_CLANG_DIR=
+BASE_PROPELLER_CLANG_DIR="$(cd $(dirname $0); pwd)"/propeller_optimize_clang.dir
 if [[ -z "${BASE_PROPELLER_CLANG_DIR}" ]]; then
     echo "Please change this script to set variable BASE_PROPELLER_CLANG_DIR to an empty directory."
     exit 1


### PR DESCRIPTION
Fix the broken url link in propeller optimization guide.

Also change the script, so users can run it without changing anything,
previously, users need to provide a customized directory.