### PR TITLE
Add `.lto_priv.`, `.part.` and `.isra.` suffixes to the list of supported suffixes. 

### DIFF
--- a/symbol_map.cc
+++ b/symbol_map.cc
@@ -65,7 +65,7 @@ void PrintSourceLocation(uint32_t start_line, uint64_t offset, int ident) {
   }
 }
 
-static const char *selectedSuffixes[] = {".cold", ".llvm."};
+static const char *selectedSuffixes[] = {".cold", ".llvm.", ".lto_priv.", ".part.", ".isra."};
 
 std::string getPrintName(const char *name) {
   char tmp_buf[1024];
@@ -291,6 +291,12 @@ std::string SymbolMap::GetOriginalName(const char *name) const {
       if (suffix == ".cold")
         StripLastOccurrenceOf(cand, suffix);
       else if (suffix == ".llvm.")
+        StripSuffixWithTwoDots(cand, suffix);
+      else if (suffix == ".lto_priv.")
+        StripSuffixWithTwoDots(cand, suffix);
+      else if (suffix == ".part.")
+        StripSuffixWithTwoDots(cand, suffix);
+      else if (suffix == ".isra.")
         StripSuffixWithTwoDots(cand, suffix);
     }
     return cand;


### PR DESCRIPTION
GCC does privatize functions to different clones when compiling with LTO under specific circumstances.

For each privatized version it adds `.lto_priv.%d` as a suffix. This patch adds support to those functions in Autofdo.