### PR TITLE
Propeller Bug Fix

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -115,6 +115,7 @@ libquipper_a_SOURCES = \
 	third_party/perf_data_converter/src/quipper/perf_parser.cc \
 	third_party/perf_data_converter/src/quipper/perf_reader.cc \
 	third_party/perf_data_converter/src/quipper/perf_serializer.cc \
+	third_party/perf_data_converter/src/quipper/perf_buildid.cc \
 	third_party/perf_data_converter/src/quipper/sample_info_reader.cc \
 	third_party/perf_data_converter/src/quipper/huge_page_deducer.cc
 nodist_libquipper_a_SOURCES = $(protoc_outputs)

--- a/llvm_profile_writer.cc
+++ b/llvm_profile_writer.cc
@@ -60,8 +60,13 @@ bool LLVMProfileBuilder::Write(const string &output_filename,
   return true;
 }
 
+#ifndef LLVM_BEFORE_SAMPLEFDO_SPLIT_CONTEXT
+const llvm::sampleprof::SampleProfileMap &LLVMProfileBuilder::ConvertProfiles(
+    const SymbolMap &symbol_map) {
+#else
 const llvm::StringMap<llvm::sampleprof::FunctionSamples>
     &LLVMProfileBuilder::ConvertProfiles(const SymbolMap &symbol_map) {
+#endif
   Start(symbol_map);
   return GetProfiles();
 }

--- a/llvm_profile_writer.h
+++ b/llvm_profile_writer.h
@@ -38,6 +38,14 @@ class LLVMProfileBuilder : public SymbolTraverser {
                     const SymbolMap &symbol_map,
                     const StringIndexMap &name_table);
 
+#ifndef LLVM_BEFORE_SAMPLEFDO_SPLIT_CONTEXT
+  const llvm::sampleprof::SampleProfileMap &ConvertProfiles(
+      const SymbolMap &symbol_map);
+
+  const llvm::sampleprof::SampleProfileMap &GetProfiles() const {
+    return profiles_;
+  }
+#else
   const llvm::StringMap<llvm::sampleprof::FunctionSamples> &ConvertProfiles(
       const SymbolMap &symbol_map);
 
@@ -45,6 +53,7 @@ class LLVMProfileBuilder : public SymbolTraverser {
       const {
     return profiles_;
   }
+#endif
 
  protected:
   void VisitTopSymbol(const string &name, const Symbol *node) override;
@@ -53,7 +62,11 @@ class LLVMProfileBuilder : public SymbolTraverser {
   llvm::StringRef GetNameRef(const string &str);
 
  private:
+#ifndef LLVM_BEFORE_SAMPLEFDO_SPLIT_CONTEXT
+  llvm::sampleprof::SampleProfileMap profiles_;
+#else
   llvm::StringMap<llvm::sampleprof::FunctionSamples> profiles_;
+#endif
   llvm::sampleprof_error result_;
   std::vector<llvm::sampleprof::FunctionSamples *> inline_stack_;
   const StringIndexMap &name_table_;

--- a/llvm_propeller_profile_format.h
+++ b/llvm_propeller_profile_format.h
@@ -5,6 +5,7 @@
 #include "llvm_propeller_profile_writer.h"
 #include "llvm_propeller_path_profile.h"
 #include "llvm_propeller_bbsections.h"
+#include "third_party/perf_data_converter/src/quipper/perf_buildid.h"
 #include "third_party/perf_data_converter/src/quipper/perf_data.pb.h"
 #include "third_party/perf_data_converter/src/quipper/perf_data_utils.h"
 

--- a/llvm_propeller_profile_writer.cc
+++ b/llvm_propeller_profile_writer.cc
@@ -703,9 +703,14 @@ bool fillELFPhdr(llvm::object::ELFObjectFileBase *ebFile,
                  map<uint64_t, ProgSegLoad> &phdrLoadMap) {
   ELFObjectFile<ELFT> *eobj = dyn_cast<ELFObjectFile<ELFT>>(ebFile);
   if (!eobj) return false;
+#if LLVM_VERSION_MAJOR >= 12
+  const ELFFile<ELFT>& efile = eobj->getELFFile();
+  auto program_headers = efile.program_headers();
+#else
   const ELFFile<ELFT> *efile = eobj->getELFFile();
   if (!efile) return false;
   auto program_headers = efile->program_headers();
+#endif
   if (!program_headers) return false;
   for (const typename ELFT::Phdr &phdr : *program_headers) {
     if (phdr.p_type != llvm::ELF::PT_LOAD ||


### PR DESCRIPTION
1. Update perf_data_converter to the newest version due to the unhandled events: 
Couldn't read event PERF_RECORD_TIME_CONV

Newest:
https://github.com/google/perf_data_converter/blob/master/src/quipper/perf_reader.cc#L379
Older one used in propeller now:
https://github.com/google/perf_data_converter/blob/75564b225722d164aba99e0d628b4a9af6e0e063/src/quipper/perf_reader.cc#L396

2. Fix LLVM 12 API changes that break the build with LLVM 12+ versions. 