### PR TITLE
DWARF Version 5 Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ function (config_without_llvm)
     util/symbolize/dwarf2reader.cc
     util/symbolize/dwarf3ranges.cc
     util/symbolize/elf_reader.cc
+    util/symbolize/index_helper.cc
   )
   add_dependencies(create_gcov_lib perf_data_proto)
   add_dependencies(create_gcov_lib perf_parser_options_proto)

--- a/util/symbolize/addr2line_inlinestack.h
+++ b/util/symbolize/addr2line_inlinestack.h
@@ -205,6 +205,11 @@ class InlineStackHandler: public Dwarf2Handler {
                                         enum DwarfForm form,
                                         uint64 data);
 
+  virtual void ProcessAttributeSigned(uint64 offset,
+                                        enum DwarfAttribute attr,
+                                        enum DwarfForm form,
+                                        int64 data);                                
+
   void set_directory_names(
       const DirectoryVector *directory_names) {
     directory_names_ = directory_names;
@@ -216,6 +221,10 @@ class InlineStackHandler: public Dwarf2Handler {
 
   void set_line_handler(LineInfoHandler *handler) {
     line_handler_ = handler;
+  }
+
+  void set_address_range_list(AddressRangeList *address_ranges) {
+    address_ranges_ = address_ranges;
   }
 
   const SubprogramInfo *GetSubprogramForAddress(uint64 address);
@@ -273,7 +282,7 @@ class InlineStackHandler: public Dwarf2Handler {
   int overlap_count_;
   bool have_two_level_line_tables_;
   bool subprogram_added_by_cu_;
-
+  
   DISALLOW_COPY_AND_ASSIGN(InlineStackHandler);
 };
 

--- a/util/symbolize/bytereader-inl.h
+++ b/util/symbolize/bytereader-inl.h
@@ -36,6 +36,17 @@ inline uint16 ByteReader::ReadTwoBytes(const char* buffer) const {
   }
 }
 
+inline uint32 ByteReader::ReadThreeBytes(const char* buffer) const {
+  const uint32 buffer0 = static_cast<uint32>(buffer[0]) & 0xff;
+  const uint32 buffer1 = static_cast<uint32>(buffer[1]) & 0xff;
+  const uint32 buffer2 = static_cast<uint32>(buffer[2]) & 0xff;
+  if (endian_ == ENDIANNESS_LITTLE) {
+    return buffer0 | buffer1 << 8 | buffer2 << 16;
+  } else {
+    return buffer2 | buffer1 << 8 | buffer0 << 16;
+  }
+}
+
 inline uint64 ByteReader::ReadFourBytes(const char* buffer) const {
   const uint32 buffer0 = static_cast<uint32>(buffer[0]) & 0xff;
   const uint32 buffer1 = static_cast<uint32>(buffer[1]) & 0xff;

--- a/util/symbolize/bytereader.cc
+++ b/util/symbolize/bytereader.cc
@@ -46,4 +46,22 @@ void ByteReader::SetAddressSize(uint8 size) {
   }
 }
 
+uint64 ByteReader::ReadInitialLength(const char* start, size_t* len) {
+    const uint64 initial_length = ReadFourBytes(start);
+    start += 4;
+
+    // In DWARF2/3, if the initial length is all 1 bits, then the offset
+    // size is 8 and we need to read the next 8 bytes for the real length.
+    if (initial_length == 0xffffffff) {
+        SetOffsetSize(8);
+        *len = 12;
+        return ReadOffset(start);
+    }
+    else {
+        SetOffsetSize(4);
+        *len = 4;
+    }
+    return initial_length;
+}
+
 }  // namespace devtools_crosstool_autofdo

--- a/util/symbolize/bytereader.h
+++ b/util/symbolize/bytereader.h
@@ -62,7 +62,11 @@ class ByteReader {
   // number.
   uint16 ReadTwoBytes(const char* buffer) const;
 
-  // Read four bytes from BUFFER and return it as an unsigned 32 bit
+  // Read three bytes from BUFFER and return it as an unsigned 32 bit
+  // number.
+  uint32 ReadThreeBytes(const char* buffer) const;
+
+  // Read four bytes from BUFFER and return it as an unsigned 64 bit
   // number.  This function returns a uint64 so that it is compatible
   // with ReadAddress and ReadOffset.  The number it returns will
   // never be outside the range of an unsigned 32 bit integer.
@@ -92,6 +96,10 @@ class ByteReader {
   // bytes currently.  Internally we support 4 and 8 byte addresses,
   // and will CHECK on anything else.
   uint64 ReadAddress(const char* buffer) const;
+
+  // Read a DWARF2/3 initial length field from START, using this reader, and
+  // report the length in LEN.  Return the actual initial length.
+  uint64 ReadInitialLength(const char* start, size_t* len);
 
  private:
   // Function pointer type for our address and offset readers.

--- a/util/symbolize/dwarf2enums.h
+++ b/util/symbolize/dwarf2enums.h
@@ -15,6 +15,9 @@
 #ifndef AUTOFDO_SYMBOLIZE_DWARF2ENUMS_H__
 #define AUTOFDO_SYMBOLIZE_DWARF2ENUMS_H__
 
+#include <map>
+#include <string>
+
 namespace devtools_crosstool_autofdo {
 
 // These enums do not follow the google3 style only because they are
@@ -85,6 +88,15 @@ enum DwarfTag {
   DW_TAG_type_unit = 0x41,
   DW_TAG_rvalue_reference_type = 0x42,
   DW_TAG_template_alias = 0x43,
+  // DWARF 5.
+  DW_TAG_coarray_type = 0x44,
+  DW_TAG_generic_subrange = 0x45,
+  DW_TAG_dynamic_type = 0x46,
+  DW_TAG_atomic_type = 0x47,
+  DW_TAG_call_site = 0x48,
+  DW_TAG_call_site_parameter = 0x49,
+  DW_TAG_skeleton_unit = 0x4a,
+  DW_TAG_immutable_type = 0x4b,
   DW_TAG_lo_user = 0x4080,
   DW_TAG_hi_user = 0xffff,
   // SGI/MIPS Extensions.
@@ -115,7 +127,6 @@ enum DwarfTag {
   DW_TAG_PGI_kanji_type      = 0xA000,
   DW_TAG_PGI_interface_block = 0xA020
 };
-
 
 enum DwarfHasChild {
   DW_children_no = 0,
@@ -150,9 +161,27 @@ enum DwarfForm {
   DW_FORM_exprloc = 0x18,
   DW_FORM_flag_present = 0x19,
   // DWARF 5.
+  DW_FORM_strx = 0x1a,
+  DW_FORM_addrx = 0x1b,
+  DW_FORM_ref_sup4 = 0x1c,
+  DW_FORM_strp_sup = 0x1d,
+  DW_FORM_data16 = 0x1e,
   DW_FORM_line_strp = 0x1f,
   // DWARF 4.
   DW_FORM_ref_sig8 = 0x20,
+  // DWARF 5.
+  DW_FORM_implicit_const = 0x21,
+  DW_FORM_loclistx = 0x22,
+  DW_FORM_rnglistx = 0x23,
+  DW_FORM_ref_sup8 = 0x24,
+  DW_FORM_strx1 = 0x25,
+  DW_FORM_strx2 = 0x26,
+  DW_FORM_strx3 = 0x27,
+  DW_FORM_strx4 = 0x28,
+  DW_FORM_addrx1 = 0x29,
+  DW_FORM_addrx2 = 0x2a,
+  DW_FORM_addrx3 = 0x2b,
+  DW_FORM_addrx4 = 0x2c,
   // Extensions for Fission.  See http://gcc.gnu.org/wiki/DebugFission.
   DW_FORM_GNU_addr_index = 0x1f01,
   DW_FORM_GNU_str_index = 0x1f02
@@ -259,6 +288,37 @@ enum DwarfAttribute {
   DW_AT_const_expr = 0x6c,
   DW_AT_enum_class = 0x6d,
   DW_AT_linkage_name = 0x6e,
+  // DWARF 5 Values
+  DW_AT_string_length_bit_size = 0x6f,
+  DW_AT_string_length_byte_size = 0x70,
+  DW_AT_rank = 0x71,
+  DW_AT_str_offsets_base = 0x72,
+  DW_AT_addr_base = 0x73,
+  DW_AT_rnglists_base = 0x74,
+  // Reserved 0x75 Unused,
+  DW_AT_dwo_name = 0x76,
+  DW_AT_reference = 0x77,
+  DW_AT_rvalue_reference = 0x78,
+  DW_AT_macros = 0x79,
+  DW_AT_call_all_calls = 0x7a,
+  DW_AT_call_all_source_calls = 0x7b,
+  DW_AT_call_all_tail_calls = 0x7c,
+  DW_AT_call_return_pc = 0x7d,
+  DW_AT_call_value = 0x7e,
+  DW_AT_call_origin = 0x7f,
+  DW_AT_call_parameter = 0x80,
+  DW_AT_call_pc = 0x81,
+  DW_AT_call_tail_call = 0x82,
+  DW_AT_call_target = 0x83,
+  DW_AT_call_target_clobbered = 0x84,
+  DW_AT_call_data_location = 0x85,
+  DW_AT_call_data_value = 0x86,
+  DW_AT_noreturn = 0x87,
+  DW_AT_alignment = 0x88,
+  DW_AT_export_symbols = 0x89,
+  DW_AT_deleted = 0x8a,
+  DW_AT_defaulted = 0x8b,
+  DW_AT_loclists_base = 0x8c,
   // SGI/MIPS extensions.
   DW_AT_MIPS_fde = 0x2001,
   DW_AT_MIPS_loop_begin = 0x2002,
@@ -347,7 +407,6 @@ enum DwarfAttribute {
   DW_AT_APPLE_property_attribute = 0x3feb,
   DW_AT_APPLE_objc_complete_type = 0x3fec
 };
-
 
 // Line number opcodes.
 enum DwarfLineNumberOps {
@@ -617,5 +676,16 @@ enum DwarfSectionId {
   DW_SECT_MACRO = 8
 };
 
-}  // namespace devtools_crosstool_autofdo
-#endif  // AUTOFDO_SYMBOLIZE_DWARF2ENUMS_H__
+enum DwarfUnitType {
+  DW_UT_compile = 0x01,
+  DW_UT_type = 0x02,
+  DW_UT_partial = 0x03,
+  DW_UT_skeleton = 0x04,
+  DW_UT_split_compile = 0x05,
+  DW_UT_split_type = 0x06,
+  DW_UT_lo_user = 0x80,
+  DW_UT_hi_user = 0xff
+};
+
+} // namespace devtools_crosstool_autofdo
+#endif // AUTOFDO_SYMBOLIZE_DWARF2ENUMS_H__

--- a/util/symbolize/dwarf3ranges.cc
+++ b/util/symbolize/dwarf3ranges.cc
@@ -21,7 +21,20 @@
 namespace devtools_crosstool_autofdo {
 
 void AddressRangeList::ReadRangeList(uint64 offset, uint64 base,
+    AddressRangeList::RangeList* ranges,  uint64 addr_base) {
+
+    if (is_rnglists_section) {
+        ReadDwarfRngListsDirectly(offset, base, ranges, addr_base);
+    }
+    else {
+        ReadDwarfRangeList(offset, base, ranges);
+    }
+
+}
+
+void AddressRangeList::ReadDwarfRangeList(uint64 offset, uint64 base,
                                      AddressRangeList::RangeList* ranges) {
+  CHECK(!is_rnglists_section);
   uint8 width = reader_->AddressSize();
 
   uint64 largest_address;
@@ -34,7 +47,7 @@ void AddressRangeList::ReadRangeList(uint64 offset, uint64 base,
 
   const char* pos = buffer_ + offset;
   do {
-    CHECK((pos + 2*width) <= (buffer_ + buffer_length_));
+    CHECK((pos + 2*width) <= buffer_ + buffer_length_);
     uint64 start = reader_->ReadAddress(pos);
     uint64 stop = reader_->ReadAddress(pos+width);
     if (start == largest_address)
@@ -45,6 +58,201 @@ void AddressRangeList::ReadRangeList(uint64 offset, uint64 base,
       ranges->push_back(make_pair(start+base, stop+base));
     pos += 2*width;
   } while (true);
+}
+
+
+void AddressRangeList::ReadDwarfRngListsDirectly(uint64 offset, uint64 base,
+                                            AddressRangeList::RangeList* ranges, uint64 addr_base) {
+  // Read rnglists from .debug_rnglists when the format was DW_FORM_sec_offset.
+  // Since we are calculating the address with DW_FORM_sec_offset,
+  // we don't care about (or need) the index to rngdatamap_ here.
+  // Therefore, we are getting the first element (rngdatamap_.begin())
+  // and getting the address_size from that element.
+  // (The address size is equal for all elements.)
+  auto i = rngdatamap_.begin();
+  CHECK(i != rngdatamap_.end());
+  ReadDwarfRngLists(base, ranges, buffer_ + offset, addr_base, i->second.address_size);
+}
+
+void AddressRangeList::ReadDwarfRngListwithOffsetArray(uint64 offset, uint64 base,
+                                            AddressRangeList::RangeList* ranges, uint64 addr_base, uint64 range_base_) {
+  auto i = rngdatamap_.find(range_base_);
+  CHECK(i != rngdatamap_.end());
+  RngListsData& rnglistsdata = i->second;                                              
+  ReadDwarfRngLists(base, ranges, buffer_ + rnglistsdata.rnglist_base_ + offset, addr_base, rnglistsdata.address_size);
+}
+
+void AddressRangeList::ReadDwarfRngLists(uint64 base,
+                                         AddressRangeList::RangeList* ranges,
+                                         const char* pos, uint64 addr_base,
+                                         uint8 address_size) {
+
+    CHECK(is_rnglists_section);
+
+    bool read_next_entry = true;
+
+    do {
+        CHECK(pos < buffer_ + buffer_length_);
+        uint8 entry_kind = reader_->ReadOneByte(pos); pos += 1;
+
+        switch (entry_kind) {
+          case DW_RLE_end_of_list: {
+            read_next_entry = false;
+            break;
+          }
+          case DW_RLE_base_addressx: {
+            size_t len = 0;
+            uint64 addr_section_address = reader_->ReadUnsignedLEB128(pos, &len); pos += len;
+            CHECK(addr_buffer_ + addr_base + addr_section_address * reader_->AddressSize()
+                   <= addr_buffer_ + addr_buffer_length_);
+            base = reader_->ReadAddress(addr_buffer_ + addr_base + addr_section_address * reader_->AddressSize());
+            break;
+          }
+          case DW_RLE_startx_endx: {
+            size_t len = 0;
+            // Start
+            uint64 start_index = reader_->ReadUnsignedLEB128(pos, &len); pos += len;
+            CHECK(pos <= buffer_ + buffer_length_);
+            const char* start_ptr = addr_buffer_ + addr_base + start_index * reader_->AddressSize();
+            CHECK(start_ptr <= (addr_buffer_ + addr_buffer_length_));
+            uint64 start = reader_->ReadAddress(start_ptr);
+            // Stop
+            uint64 stop_index = reader_->ReadUnsignedLEB128(pos, &len); pos += len;
+            CHECK(pos <= buffer_ + buffer_length_);
+            const char* stop_ptr = addr_buffer_ + addr_base + stop_index * reader_->AddressSize();
+            CHECK(stop_ptr <= (addr_buffer_ + addr_buffer_length_));
+            uint64 stop = reader_->ReadAddress(stop_ptr);
+            if (start != stop)
+              ranges->push_back (make_pair (start + base, stop + base));
+            break;
+          }
+          case DW_RLE_startx_length: {
+            size_t len = 0;
+            // Start
+            uint64 start_index = reader_->ReadUnsignedLEB128(pos, &len); pos += len;
+            CHECK(pos <= buffer_ + buffer_length_);
+            const char* start_ptr = addr_buffer_ + addr_base + start_index * reader_->AddressSize();
+            CHECK(start_ptr <= (addr_buffer_ + addr_buffer_length_));
+            uint64 start = reader_->ReadAddress(start_ptr);
+            // Length
+            uint64 range_length = reader_->ReadUnsignedLEB128(pos, &len); pos += len;
+            CHECK(pos <= buffer_ + buffer_length_);
+            if (range_length != 0)
+              ranges->push_back (make_pair (start + base, start + base + range_length));
+            break;
+          }
+          case DW_RLE_offset_pair: {
+            size_t len = 0;
+            uint64 start = reader_->ReadUnsignedLEB128(pos, &len); pos += len;
+            CHECK(pos <= buffer_ + buffer_length_);
+            uint64 stop = reader_->ReadUnsignedLEB128(pos, &len); pos += len;
+            CHECK(pos <= buffer_ + buffer_length_);
+            if (start != stop)
+              ranges->push_back (make_pair (start + base, stop + base));
+            break;
+          }
+          case DW_RLE_base_address: {
+            CHECK(pos + address_size <= buffer_ + buffer_length_);
+            base = reader_->ReadAddress(pos); pos += address_size;
+            break;
+          case DW_RLE_start_end:
+            size_t len = 0;
+            uint64 start = reader_->ReadAddress(pos); pos += address_size;
+            CHECK(pos <= buffer_ + buffer_length_);
+            uint64 stop = reader_->ReadAddress(pos); pos += address_size;
+            CHECK(pos <= buffer_ + buffer_length_);
+            if (start != stop)
+              ranges->push_back (make_pair (start, stop));
+            break;
+          }
+          case DW_RLE_start_length: {
+            size_t len = 0;
+            uint64 start = reader_->ReadAddress(pos); pos += address_size;
+            CHECK(pos <= buffer_ + buffer_length_);
+            // Length
+            uint64 range_length = reader_->ReadUnsignedLEB128(pos, &len); pos += len;
+            CHECK(pos <= buffer_ + buffer_length_);
+            if (range_length != 0)
+              ranges->push_back (make_pair (base + start, base + start + range_length));
+            break;
+          }
+          default: { 
+            LOG(FATAL) << "Unhandled range list entry kind";
+            break;
+          }
+        }
+    } while (read_next_entry);
+}
+
+void AddressRangeList::ReadDwarfRngListsHeader() {
+    CHECK(is_rnglists_section);
+
+    const char* ptr = buffer_;
+
+    do {
+      const char* section_start_ptr = ptr;
+
+      RngListsData rnglistsdata;
+
+      CHECK(ptr + 12 < buffer_ + buffer_length_);
+      // unit_length (initial length)
+      size_t unit_length_size;
+      rnglistsdata.unit_length = reader_->ReadInitialLength(ptr, &unit_length_size);
+
+      CHECK(unit_length_size + rnglistsdata.unit_length <= buffer_length_);
+      ptr += unit_length_size;
+
+      CHECK(ptr + 2 < buffer_ + buffer_length_);
+      rnglistsdata.version = reader_->ReadTwoBytes(ptr);
+      CHECK(rnglistsdata.version == 5);
+      ptr += 2;
+
+      CHECK(ptr + 1 < buffer_ + buffer_length_);
+      rnglistsdata.address_size = reader_->ReadOneByte(ptr);
+      ptr += 1;
+
+      CHECK(ptr + 1 < buffer_ + buffer_length_);
+      rnglistsdata.segment_selector_size = reader_->ReadOneByte(ptr);
+      ptr += 1;
+
+      CHECK(ptr + 4 < buffer_ + buffer_length_);
+      rnglistsdata.offset_entry_count = reader_->ReadFourBytes(ptr);
+      ptr += 4;
+      
+      rnglistsdata.rnglist_base_ = ptr - buffer_;
+
+      if(rnglistsdata.offset_entry_count != 0) {
+        for(int i = 0; i < rnglistsdata.offset_entry_count; ++i) {
+          rnglistsdata.offset_list_.push_back(ReadOffset(&ptr));
+        }
+      }
+      rngdatamap_[rnglistsdata.rnglist_base_] = rnglistsdata;
+
+      // Jump to next header inside .debug_rnglists
+      ptr = section_start_ptr + (rnglistsdata.unit_length + unit_length_size); 
+      
+    } while(ptr < buffer_ + buffer_length_); 
+
+}
+
+uint64 AddressRangeList::GetRngListsElementOffsetByIndex(uint64 range_base, uint64 rng_index) {
+    auto i = rngdatamap_.find(range_base);
+    CHECK(i != rngdatamap_.end());
+    RngListsData rnglistsdata = i->second;
+    if (rnglistsdata.offset_entry_count == 0) {
+      LOG(WARNING) << "If the offset_entry_count is zero, then DW_FORM_rnglistx cannot be used to access a range list; DW_FORM_sec_offset must be used instead. If the offset_entry_count is non-zero, then DW_FORM_rnglistx may be used to access a range list; this is necessary in split units and may be more compact than using DW_FORM_sec_offsetin non-split units. (Page 242, DWARF5 Specification document).";
+      return 0;
+    }
+    CHECK(rng_index < rnglistsdata.offset_list_.size());
+    return rnglistsdata.offset_list_[rng_index];
+  }
+
+uint64 AddressRangeList::ReadOffset(const char** offsetarrayptr)
+{
+    CHECK(*offsetarrayptr + reader_->OffsetSize() < buffer_ + buffer_length_);
+    uint64 offset = reader_->ReadOffset(*offsetarrayptr);
+    *offsetarrayptr = *offsetarrayptr + reader_->OffsetSize();
+    return offset;
 }
 
 }  // namespace devtools_crosstool_autofdo

--- a/util/symbolize/functioninfo.cc
+++ b/util/symbolize/functioninfo.cc
@@ -244,20 +244,34 @@ void CUFunctionInfoHandler::ProcessAttributeUnsigned(uint64 offset,
                                                      uint64 data) {
   if (attr == DW_AT_stmt_list) {
     SectionMap::const_iterator line_sect = sections_.find(".debug_line");
-    CHECK(line_sect != sections_.end());
-
-    SectionMap::const_iterator str_sect = sections_.find(".debug_line_str");
+    CHECK(line_sect != sections_.end()) << "unable to find .debug_line "
+        "in section map";
+    SectionMap::const_iterator line_str = sections_.find(".debug_line_str");
     const char* line_str_buffer = NULL;
     uint64 line_str_size = 0;
-    if (str_sect != sections_.end()) {
-      line_str_buffer = str_sect->second.first;
-      line_str_size = str_sect->second.second;
+    if (line_str != sections_.end()) {
+      line_str_buffer = line_str->second.first;
+      line_str_size = line_str->second.second;
     }
-
-    LineInfo lireader(line_sect->second.first + data,
-                      line_sect->second.second  - data,
-                      line_str_buffer,
-                      line_str_size,
+    SectionMap::const_iterator str_section = sections_.find(".debug_str");
+    const char* str_buffer = NULL;
+    uint64 str_buffer_size = 0;
+    if (str_section != sections_.end()) {
+      str_buffer = line_str->second.first;
+      str_buffer_size = line_str->second.second;
+    }
+    SectionMap::const_iterator str_offset = sections_.find(".debug_line_str");
+    const char* str_offset_buffer = NULL;
+    uint64 str_offset_size = 0;
+    if (str_offset != sections_.end()) {
+      str_offset_buffer = line_str->second.first;
+      str_offset_size = line_str->second.second;
+    }                    
+    LineInfo lireader(line_sect->second.first + data, line_sect->second.second - data,
+                      line_str_buffer, line_str_size,
+                      str_buffer, str_buffer_size,
+                      str_offset_buffer, str_offset_size,
+                      get_str_offset_base(),
                       reader_, linehandler_);
     lireader.Start();
   } else if (current_function_info_) {

--- a/util/symbolize/index_helper.cc
+++ b/util/symbolize/index_helper.cc
@@ -1,0 +1,44 @@
+
+#include "index_helper.h"
+
+namespace devtools_crosstool_autofdo {
+
+
+const char* get_string_with_offsets(const char* string_buffer,
+                                    uint64 string_buffer_length,
+                                    uint64 offset) {
+  if (offset >= string_buffer_length) {
+    LOG(WARNING) << "offset is out of range.  offset=" << offset
+                  << " string_buffer_length_=" << string_buffer_length;
+    return NULL;
+  }
+  return string_buffer + offset;
+}
+
+const char* get_offset_pointer_in_str_offsets_table(uint64 str_index,
+                                              const char* str_offset_buffer,
+                                              uint64 str_offset_base,
+                                              uint8 offset_size, 
+                                              uint16 version){
+  const char* offset_ptr =
+      str_offset_buffer + str_offset_base + (str_index * offset_size);
+
+  // In DWARF5 we have to include base_address to the calculation. 
+  if (version == 5)
+    offset_ptr =
+      str_offset_buffer + str_offset_base + (str_index * offset_size);
+  else if (version < 5)
+    offset_ptr = 
+      str_offset_buffer + str_index * offset_size;
+
+  return offset_ptr;
+}
+
+const char* get_address_pointer_from_address_table(const char* addr_buffer, 
+                                                    uint64 addr_base,
+                                                    uint64 addr_index,
+                                                    uint8 addr_size){
+  return addr_buffer + addr_base + addr_index * addr_size;
+}
+
+}  // namespace devtools_crosstool_autofdo

--- a/util/symbolize/index_helper.h
+++ b/util/symbolize/index_helper.h
@@ -1,0 +1,45 @@
+
+
+#ifndef AUTOFDO_SYMBOLIZE_INDEX_HELPER_H__
+#define AUTOFDO_SYMBOLIZE_INDEX_HELPER_H__
+
+#include "base/common.h"
+
+
+namespace devtools_crosstool_autofdo {
+
+
+// string_buffer : as pointer to begining of .debug_str
+// string_buffer_length : total of the string_buffer (.debug_str) 
+// offset : offset of the string we want
+// return a pointer pointing at the begining of that string.
+const char* get_string_with_offsets(const char* string_buffer,
+                                    uint64 string_buffer_length,
+                                    uint64 offset);
+
+
+//  str_index : index of the string we want
+//  str_offset_buffer : as pointer to begining of .debug_str_offsets
+//  str_offset_base : base address of the .debug_str_offsets section
+//  offset_size : the size of offsets in architecture/version
+//  version : version of header in .debug_str_offsets
+// return a pointer to memory location, containing offset for the string with index str_index.
+const char* get_offset_pointer_in_str_offsets_table(uint64 str_index,
+                                                    const char* str_offset_buffer,
+                                                    uint64 str_offset_base,
+                                                    uint8 offset_size, 
+                                                    uint16 version);
+
+//  addr_buffer : pointer to .debug_addr buffer.
+//  addr_base : base address of the .debug_addr section.
+//  addr_index : the index of the address we want
+//  addr_size : size of an andress in this architecture/version
+// return a pointer to memory location, containing the address we want.
+const char* get_address_pointer_from_address_table(const char* addr_buffer, 
+                                                    uint64 addr_base,
+                                                    uint64 addr_index,
+                                                    uint8 addr_size);
+
+}  // namespace devtools_crosstool_autofdo
+
+#endif  // AUTOFDO_SYMBOLIZE_INDEX_HELPER_H__


### PR DESCRIPTION
In this pull request, I am adding DWARF 5 support to AutoFDO. The PR has been tested on a) my private testcases, b) GCC AutoFDO test cases (no regression). 

Here is a list of differences between version 4 and version 4 from DWARF standard, and in each case, in front of it you can see the status of implementation. 

Thanks to Eugene Rozenfeld (@erozenfeld) for his help during my work on this. 

## Changes from Version 4 to Version 5.
1.  Eliminate the `.debug_types` section introduced in DWARF Version 4 and move its contents into the `.debug_info` section.
    * We don't use `.debug_types` information in Autofdo.
2.  Add support for collecting common DWARF information (debugging information entries and macro definitions) across multiple executable and shared files and keeping it in a single supplementary object file.
    * Only full compilation units, partial compilation units, and type units are supported.
3.  Replace the line number program header format with a new format that provides the ability to use an MD5 hash to validate the source file version in use, allows pooling of directory and file name strings and makes provision for vendor-defined extensions. Also add a string section specific to the line number table (`.debug_line_str`) to properly support the common practice of stripping all DWARF sections except for line number information.
    * Implemented.
4.  Add a split object file and package representations to allow most DWARF information to be kept separate from an executable or shared image. This includes new sections `.debug_addr`, .debug_str_offsets, .debug_abbrev.dwo, `.debug_info.dwo`, `.debug_line.dwo`, `.debug_loclists.dwo`, `.debug_macro.dwo`, `.debug_str.dwo`, `.debug_str_offsets.dwo`, `.debug_cu_index` and `.debug_tu_index` together with new forms of attribute value for referencing these sections. This enhances DWARF support by reducing executable program size and by improving link times.
    * Implemented.
5.  Replace the `.debug_macinfo` macro information representation with with a `.debug_macro` representation that can potentially be much more compact.
    * We don't use `.debug_macro` and `.debug_macinfo` in autofdo.
6.  Replace the `.debug_pubnames` and `.debug_pubtypes` sections with a single and more functional name index section, `.debug_names`.
    * We don't use `.debug_pubnames` and `.debug_pubtypes`. 
7.  Replace the location list and range list sections (`.debug_loc` and `.debug_ranges`, respectively) with new sections (`.debug_loclists` and `.debug_rnglists`) and new representations that save space and processing time by eliminating most related object file relocations.
    * We don't use `.debug_loclists`.
    * New `.debug_rnglists` is fully implemented.
8.  Add a new debugging information entry (`DW_TAG_call_site`), related attributes and DWARF expression operators to describe call site information, including identification of tail calls and tail recursion.
    * We don't use `DW_TAG_call_site` in Autofdo. 
9.  Add improved support for FORTRAN assumed rank arrays (`DW_TAG_generic_subrange`), dynamic rank arrays (`DW_AT_rank`) and co-arrays (`DW_TAG_coarray_type`).
    * We don't use `DW_TAG_generic_subrange`, `DW_AT_rank` and `DW_TAG_coarray_type`.
10.  Add new operations that allow support for a DWARF expression stack containing typed values.
    * The only place we support DWARF expression (`DW_FORM_exprloc`) is related to locations and strings. We don't need this information since it is related to typed values.
11.  Add improved support for the C++: auto return type, deleted member functions (`DW_AT_deleted`), as well as defaulted constructors and destructors (`DW_AT_defaulted`).
    * We don't use `DW_AT_defaulted`.
12.  Add a new attribute (`DW_AT_noreturn`), to identify a subprogram that does not return to its caller.
    * We don't use `DW_AT_noreturn`.
13.  Add language codes for `C 2011`, `C++ 2003`, `C++ 2011`, `C++ 2014`, `Dylan`, `Fortran 2003`, `Fortran 2008`, `Go`, `Haskell`, `Julia`, `Modula 3`, `Ocaml`, `OpenCL`, `Rust` and `Swift`.
14.  Numerous other more minor additions to improve functionality and performance.


## Incomppatibilities between Version 4 to Version 5.
1.  The compilation unit header (in the `.debug_info` section) has a new `unit_type` field. In addition, the `debug_abbrev_offset` and `address_size` fields are reordered.
    * Implemented.
2.  New operand forms for attribute values are defined (`DW_FORM_addrx`, `DW_FORM_addrx1`, `DW_FORM_addrx2`, `DW_FORM_addrx3`, `DW_FORM_addrx4`, `DW_FORM_data16`, `DW_FORM_implicit_const`, `DW_FORM_line_strp`, `DW_FORM_loclistx`, `DW_FORM_rnglistx`, `DW_FORM_ref_sup4`, `DW_FORM_ref_sup8`, `DW_FORM_strp_sup`, `DW_FORM_strx`, `DW_FORM_strx1`, `DW_FORM_strx2`, `DW_FORM_strx3` and `DW_FORM_strx4`.
    * All of them implemented in related attributes (`DW_AT_`).
3.  The line number table header is substantially revised.
    * Implemented.
4.  The `.debug_loc` and `.debug_ranges` sections are replaced by new `.debug_loclists` and `.debug_rnglists` sections, respectively. These new sections have a new (and more efficient) list structure. Attributes that reference the predecessor sections must be interpreted differently to access the new sections. The new sections encode the same information as their predecessors, except that a new default location list entry is added.
    * We don't use `.debug_loclists`.
    * New `.debug_rnglists` is fully implemented.
5.  In a string type, the `DW_AT_byte_size` attribute is re-defined to always describe the size of the string type. (Previously it described the size of the optional string length data field if the `DW_AT_string_length` attribute was also present.) In addition, the `DW_AT_string_length` attribute may now refer directly to an object that contains the length value.
    * We don't use this attribute.
6.  While not strictly an incompatibility, the macro information representation is completely new; further, producers and consumers may optionally continue to support the older representation. While the two representations cannot both be used in the same compilation unit, they can co-exist in executable or shared images.
    * We don't use any macro information.
7.  Similar comments apply to replacement of the `.debug_pubnames` and `.debug_pubtypes` sections with the new `.debug_names` section.
    * We don't use any information from `.debug_pubnames` and `.debug_pubtypes` or `.debug_names`.



