### PR TITLE
Reapply fix for dump_gcov

### DIFF
--- a/profile_reader.cc
+++ b/profile_reader.cc
@@ -112,8 +112,7 @@ bool AutoFDOProfileReader::ReadFromFile(const std::string &output_file) {
 
   // Read tags
   CHECK_EQ(gcov_read_unsigned(), GCOV_DATA_MAGIC) << output_file;
-  CHECK_EQ(gcov_read_unsigned(), absl::GetFlag(FLAGS_gcov_version))
-      << output_file;
+  absl::SetFlag(&FLAGS_gcov_version, gcov_read_unsigned());
   gcov_read_unsigned();
 
   ReadNameTable();


### PR DESCRIPTION
The fix for dump_gov introduced in b3196d671a81dc80800df21e68ec0018e87f974a was overwritten by 055eb26864b19be0a9044e88bd5655e7ceedfb52. This patch reapplies the fix.