### PR TITLE
Fix code related to some recent changes in LLVM

### DIFF
--- a/addr2line.cc
+++ b/addr2line.cc
@@ -98,13 +98,13 @@ void LLVMAddr2line::GetInlineStack(uint64_t address, SourceStack *stack) const {
     std::string dir_name;
     if (line_table->hasFileAtIndex(file)) {
       const auto &entry = line_table->Prologue.getFileNameEntry(file);
-      file_name = llvm::dwarf::toString(entry.Name).getValue();
+      file_name = llvm::dwarf::toString(entry.Name).value();
       if (entry.DirIdx > 0 &&
           entry.DirIdx <= line_table->Prologue.IncludeDirectories.size())
         dir_name =
             llvm::dwarf::toString(
                 line_table->Prologue.IncludeDirectories[entry.DirIdx - 1])
-                .getValue();
+                .value();
     }
     stack->emplace_back(function_name, dir_name, file_name, start_line, line,
                         discriminator);

--- a/llvm_propeller_profile_writer.cc
+++ b/llvm_propeller_profile_writer.cc
@@ -318,8 +318,8 @@ bool PropellerProfWriter::Write(
     // picked by the compiler.
     for (auto &func_name : func_names) {
       symorder_stream << func_name.str();
-      if (cluster_id.hasValue())
-        symorder_stream << ".__part." << cluster_id.getValue();
+      if (cluster_id.has_value())
+        symorder_stream << ".__part." << *cluster_id;
       symorder_stream << "\n";
     }
   }

--- a/perfdata_reader.cc
+++ b/perfdata_reader.cc
@@ -265,7 +265,7 @@ llvm::Optional<std::set<std::string>> FindFileNameInPerfDataWithFileBuildId(
     BinaryPerfInfo *info) {
   if (info->binary_info.build_id.empty()) {
     LOG(INFO) << "No Build Id found in '" << binary_file_name << "'.";
-    return llvm::None;
+    return std::nullopt;
   }
   LOG(INFO) << "Build Id found in '" << binary_file_name
             << "': " << info->binary_info.build_id;
@@ -277,7 +277,7 @@ llvm::Optional<std::set<std::string>> FindFileNameInPerfDataWithFileBuildId(
                 << "' has filename '" << fn << "'.";
     return buildid_names;
   }
-  return llvm::None;
+  return std::nullopt;
 }
 
 // Select mmaps from perf.data.


### PR DESCRIPTION
As of current TOT LLVM (past LLVM 15), the API for LLVM::Optional has changed significantly, and LLVM::None has been deprecated and many pieces have been switched over to use std::optional. This patch fixes the compilation of autoFDO in relation to these new changes.