### PR TITLE
Fix LLVM profile merger flags

### DIFF
--- a/profile_merger.cc
+++ b/profile_merger.cc
@@ -153,7 +153,7 @@ int main(int argc, char **argv) {
     using devtools_crosstool_autofdo::AutoFDOProfileReader;
     typedef std::unique_ptr<AutoFDOProfileReader> AutoFDOProfileReaderPtr;
     std::unique_ptr<AutoFDOProfileReaderPtr[]> readers(
-        new AutoFDOProfileReaderPtr[argc - 1]);
+        new AutoFDOProfileReaderPtr[positionalArguments.size() - 1]);
     // TODO(dehao): merge profile reader/writer into a single class
     for (int i = 1; i < positionalArguments.size(); i++) {
       readers[i - 1] =

--- a/profile_merger.cc
+++ b/profile_merger.cc
@@ -129,7 +129,7 @@ bool verifyProperFlags(bool has_prof_sym_list) {
 
 int main(int argc, char **argv) {
   absl::SetProgramUsageMessage(argv[0]);
-  absl::ParseCommandLine(argc, argv);
+  std::vector<char*> positionalArguments = absl::ParseCommandLine(argc, argv);
   devtools_crosstool_autofdo::SymbolMap symbol_map;
 
   if (argc < 2) {
@@ -155,10 +155,10 @@ int main(int argc, char **argv) {
     std::unique_ptr<AutoFDOProfileReaderPtr[]> readers(
         new AutoFDOProfileReaderPtr[argc - 1]);
     // TODO(dehao): merge profile reader/writer into a single class
-    for (int i = 1; i < argc; i++) {
+    for (int i = 1; i < positionalArguments.size(); i++) {
       readers[i - 1] =
           std::make_unique<AutoFDOProfileReader>(&symbol_map, true);
-      readers[i - 1]->ReadFromFile(argv[i]);
+      readers[i - 1]->ReadFromFile(positionalArguments[i]);
     }
 
     symbol_map.CalculateThreshold();
@@ -173,7 +173,7 @@ int main(int argc, char **argv) {
     typedef std::unique_ptr<LLVMProfileReader> LLVMProfileReaderPtr;
 
     std::unique_ptr<LLVMProfileReaderPtr[]> readers(
-        new LLVMProfileReaderPtr[argc - 1]);
+        new LLVMProfileReaderPtr[positionalArguments.size() - 1]);
     llvm::sampleprof::ProfileSymbolList prof_sym_list;
 
 #if LLVM_VERSION_MAJOR >= 12
@@ -181,11 +181,11 @@ int main(int argc, char **argv) {
     int numFSDProfiles = 0;
 #endif
 
-    for (int i = 1; i < argc; i++) {
+    for (int i = 1; i < positionalArguments.size(); i++) {
       auto reader = std::make_unique<LLVMProfileReader>(
           &symbol_map, names,
           absl::GetFlag(FLAGS_merge_special_syms) ? nullptr : &special_syms);
-      CHECK(reader->ReadFromFile(argv[i])) << "when reading " << argv[i];
+      CHECK(reader->ReadFromFile(positionalArguments[i])) << "when reading " << positionalArguments[i];
 
 #if LLVM_VERSION_MAJOR >= 12
       if (reader->ProfileIsFS()) {


### PR DESCRIPTION
Currently the LLVM profile merger interprets all the flags passed on the command line as input files. This makes it impossible to pass flags into the executable as they will be interpreted as files and then the profile reader will fail due to the file not existing. This patch fixes that behavior by taking the leftover positional arguments from the absl flag parsing function.

I might be missing something here in terms of how this application is supposed to be actually used because I assume it worked properly at some point, but I can't see anything in the commit history that would indicate that (but that is pretty limited given there are only a couple copybara imports).