### PR TITLE
Add DWARF5 attribute forms DW_FORM_line_strp

### DIFF
--- a/util/symbolize/dwarf2reader.h
+++ b/util/symbolize/dwarf2reader.h
@@ -685,6 +685,11 @@ class CompilationUnit {
   const char* str_offsets_buffer_;
   uint64 str_offsets_buffer_length_;
 
+  // Add a string section specific to the line number table (.debug_line_str)
+  // since DWARF5.
+  const char* line_str_buffer_;
+  uint64 line_str_buffer_length_;
+
   // Address section buffer and length, if we have an address section
   // (.debug_addr).
   const char* addr_buffer_;


### PR DESCRIPTION
v2 of PR https://github.com/google/autofdo/issues/159

This submit try to fix issue #159 [0]

Dwarf5 add a string section specific to the line number table ( .debug_line_str ) to properly support the common practice of stripping all DWARF sections except for line number information.

And gcc[1] commit 3aa46b47b266("dwarf2out.c (debug_line_str_section): New variable.") introduct DW_FORM_line_strp = 31(0x1f).

  Error message:

```
  $ perf record -b -e br_inst_retired.near_taken:pp -- ./redis-server
  $ create_gcov --binary=./redis-server --profile=perf.data \
	--gcov=redis-server.gcov -gcov_version=1
  ...
  F20230317 14:17:19.056878 32875 dwarf2reader.cc:836] Unhandled form type
  *** Check failure stack trace: ***
  Aborted (core dumped)
```

[0] https://github.com/google/autofdo/issues/159
[1] git://gcc.gnu.org/git/gcc.git