### PR TITLE
Clean up warnings produced by create_gcov

### DIFF
--- a/profile.cc
+++ b/profile.cc
@@ -194,7 +194,7 @@ void Profile::ComputeProfile() {
 
     for (const auto &[name, profile] : symbol_profile_maps_) {
       const uint64_t count = symbol_counts.at(absl::StripSuffix(name, ".cold"));
-      if (symbol_map_->ShouldEmit(count)) {
+      if (symbol_map_->ShouldEmit(count) && (profile->GetAggregatedCount() != 0)) {
         ProcessPerFunctionProfile(name, *profile);
       }
     }

--- a/sample_reader.cc
+++ b/sample_reader.cc
@@ -277,7 +277,7 @@ bool PerfDataSampleReader::Append(const std::string &profile_file) {
     if (focus_bins_.empty())
       return false;
   } else {
-    LOG(ERROR) << "No buildid found in binary";
+    LOG(WARNING) << "No buildid found in binary";
   }
 
   for (const auto &event : parser.parsed_events()) {


### PR DESCRIPTION
1. Don't emit warnings when optional sections are not present, e.g., .debug_addr.
2. Don't attempt to process per-function profile if the function has a 0 aggregated count. This was resulting in a bogus "use_lbr was enabled but range_count_map was empty!" warning when processing a function with .cold suffix.
3. Change "No buildid found in binary" from error to warning since we can tolerate binaries without build id.