### PR TITLE
Fixed dependency error.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,7 +214,7 @@ function (config_with_llvm)
   add_dependencies(llvm_propeller_mock_whole_program_info llvm_propeller_options)
   add_dependencies(llvm_propeller_mock_whole_program_info llvm_propeller_cfg_proto)
   add_library(create_llvm_prof_object OBJECT create_llvm_prof.cc)
-  add_dependencies(create_llvm_prof_object llvm_propeller_options)
+  add_dependencies(create_llvm_prof_object llvm_propeller_options LLVMDebugInfoDWARF)
 
   add_library(sample_reader OBJECT sample_reader.cc)
   target_include_directories(sample_reader PUBLIC util)


### PR DESCRIPTION
"llvm/IR/IntrinsicEnums.inc", which is part of LLVMDebugInfoDWARF, is required when building create_llvm_prof.cc Added LLVMDebugInfoDWARF to create_llvm_prof.cc's dep list.

It is a confluence of circumstances that this error was not caught while building on my workstation, the reason being that it has so many cores (>100), that LLVMDebugInfoDWARF is built as other's deplist, prior to create_llvm_prof.cc. I reproduced it when building on my other workstation with 24 cores.