### PR TITLE
Fixed two bugs 1) buildid is not properly read; 2) BBAddressMap.getFunctionAddress causes segfault.

### DIFF
--- a/llvm_propeller_whole_program_info.cc
+++ b/llvm_propeller_whole_program_info.cc
@@ -578,10 +578,7 @@ void PropellerWholeProgramInfo::DropNonSelectedFunctions(
   for (int i = 0; i != bb_addr_map_.size(); ++i) {
     if (selected_functions.contains(i))
       continue;
-    bb_addr_map_[i].BBRanges.clear();
-    bb_addr_map_[i].BBRanges.shrink_to_fit();
-    if (!options_.keep_frontend_intermediate_data())
-      symtab_.erase(bb_addr_map_[i].getFunctionAddress());
+    symtab_.erase(bb_addr_map_[i].getFunctionAddress());
   }
 }
 

--- a/perfdata_reader.cc
+++ b/perfdata_reader.cc
@@ -62,7 +62,7 @@ template <class ELFT> std::string ELFFileUtil<ELFT>::GetBuildId() {
       llvm::StringRef r = note.getName();
       if (r == kBuildIdNoteName) {
         // Or use shdr.sh_addralign instead of 0?
-        llvm::ArrayRef<uint8_t> build_id = note.getDesc(/*Align=*/0);
+        llvm::ArrayRef<uint8_t> build_id = note.getDesc(shdr.sh_addralign);
         std::string build_id_str(build_id.size() * 2, '0');
         int k = 0;
         for (uint8_t t : build_id) {

--- a/perfdata_reader.cc
+++ b/perfdata_reader.cc
@@ -61,7 +61,6 @@ template <class ELFT> std::string ELFFileUtil<ELFT>::GetBuildId() {
     for (const typename ELFT::Note &note : elf_file_->notes(shdr, err)) {
       llvm::StringRef r = note.getName();
       if (r == kBuildIdNoteName) {
-        // Or use shdr.sh_addralign instead of 0?
         llvm::ArrayRef<uint8_t> build_id = note.getDesc(shdr.sh_addralign);
         std::string build_id_str(build_id.size() * 2, '0');
         int k = 0;


### PR DESCRIPTION
Fixed two bugs - 
  1) buildid is not properly read and 
  2) deleting a symbol from symtab causes segfault - bb_addr_map.getFunctionAddress() uses BBRanges[0] to calculate function address, we should not call "clear" on BBRanges before deleting this.