### PR TITLE
Removed WITH_LLVM and replaced protobuf_generate_cpp with more modern protobuf_generate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,10 +14,10 @@ function (execute_perf_protobuf)
     third_party/perf_data_converter/src/quipper/perf_stat.proto)
   protobuf_generate(TARGET perf_proto LANGUAGE cpp)
   target_link_libraries(perf_proto PUBLIC protobuf::libprotobuf)
-  
+
 endfunction()
 
-function (config_without_llvm)
+function (build_gcov)
   add_subdirectory(third_party/abseil)
   add_subdirectory(third_party/glog)
 
@@ -54,7 +54,7 @@ function (config_without_llvm)
   )
   target_link_libraries(create_gcov_lib perf_proto)
 
-  add_library(quipper_perf OBJECT 
+  add_library(quipper_perf OBJECT
     third_party/perf_data_converter/src/quipper/address_mapper.cc
     third_party/perf_data_converter/src/quipper/base/logging.cc
     third_party/perf_data_converter/src/quipper/binary_data_utils.cc
@@ -133,7 +133,7 @@ function (config_without_llvm)
 
 endfunction()
 
-function (config_with_llvm)
+function (build_llvm)
   execute_process(COMMAND sh -c "git -C ${CMAKE_HOME_DIRECTORY}/third_party/llvm-project log -1 --format=%h"
      RESULT_VARIABLE clang_version_status
      OUTPUT_VARIABLE CLANG_VERSION_OUTPUT)
@@ -155,9 +155,9 @@ function (config_with_llvm)
   set (LLVM_INCLUDE_TESTS OFF)
   set (LLVM_INCLUDE_TOOLS OFF)
   set (LLVM_INCLUDE_DOCS OFF)
-  
+
   set (LLVM_ENABLE_RTTI ON)
-  set (LLVM_ENABLE_PROJECTS clang CACHE STRING 
+  set (LLVM_ENABLE_PROJECTS clang CACHE STRING
     "Semicolon-separated list of projects to build (${LLVM_KNOWN_PROJECTS}), or \"all\".")
   set (LLVM_TARGETS_TO_BUILD X86 AArch64 CACHE STRING
     "Semicolon-separated list of LLVM targets to build, or \"all\".")
@@ -169,7 +169,7 @@ function (config_with_llvm)
   add_subdirectory(third_party/googletest)
   add_subdirectory(third_party/llvm-project/llvm)
 
-  add_custom_target(exclude_extlib_tests ALL 
+  add_custom_target(exclude_extlib_tests ALL
     COMMAND rm -f ${gtest_BINARY_DIR}/CTestTestfile.cmake
     COMMAND rm -f ${gmock_BINARY_DIR}/CTestTestfile.cmake
     COMMAND rm -f ${googletest-distribution_BINARY_DIR}/CTestTestfile.cmake
@@ -195,7 +195,7 @@ function (config_with_llvm)
   add_library(llvm_propeller_cfg_proto llvm_propeller_cfg.proto)
   protobuf_generate(TARGET llvm_propeller_cfg_proto LANGUAGE cpp)
   target_link_libraries(llvm_propeller_cfg_proto PUBLIC protobuf::libprotobuf)
-  
+
   add_library(llvm_propeller_options_proto llvm_propeller_options.proto)
   target_link_libraries(llvm_propeller_options_proto PUBLIC
     protobuf::libprotobuf)
@@ -327,7 +327,7 @@ function (config_with_llvm)
     LLVMSupport)
 
   add_executable(create_llvm_prof create_llvm_prof.cc)
-  target_link_libraries(create_llvm_prof 
+  target_link_libraries(create_llvm_prof
     absl::base
     absl::check
     absl::flags
@@ -419,7 +419,7 @@ function (config_with_llvm)
     llvm_propeller_binary_address_mapper.cc
     llvm_propeller_binary_content.cc
     llvm_propeller_cfg.cc
-    llvm_propeller_chain_cluster_builder.cc 
+    llvm_propeller_chain_cluster_builder.cc
     llvm_propeller_code_layout.cc
     llvm_propeller_code_layout_scorer.cc
     llvm_propeller_formatting.cc
@@ -748,7 +748,7 @@ function (config_with_llvm)
   add_library(llvm_propeller_cfg OBJECT llvm_propeller_cfg.cc)
   add_library(llvm_propeller_formatting OBJECT llvm_propeller_formatting.cc)
 
-  add_library(quipper_perf OBJECT 
+  add_library(quipper_perf OBJECT
     third_party/perf_data_converter/src/quipper/address_mapper.cc
     third_party/perf_data_converter/src/quipper/arm_spe_decoder.cc
     third_party/perf_data_converter/src/quipper/base/logging.cc
@@ -788,10 +788,23 @@ function (config_with_llvm)
     DEPENDS prepare_cmds)
 endfunction()
 
+if (DEFINED ENABLE_TOOL)
+   string(TOLOWER ${ENABLE_TOOL} enable_tool)
+else()
+   set(enable_tool llvm)
+endif()
+
+# perf protobuf is required by both tools.
 execute_perf_protobuf()
-if (DEFINED WITH_LLVM)
-  config_with_llvm()
+if (${enable_tool} STREQUAL gcov)
+  message(STATUS "Building tool \"GCOV\" ...")
+  build_gcov()
+elseif (${enable_tool} STREQUAL llvm)
+  message(STATUS "Building tool \"LLVM\" ...")
+  build_llvm()
 else ()
-  config_without_llvm()
+  message(FATAL_ERROR
+    "ENABLE_TOOL must equal to one of \"LLVM\" (default) or \"GCOV\"")
 endif ()
+
 enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ function (execute_perf_protobuf)
     third_party/perf_data_converter/src/quipper/perf_stat.proto)
   protobuf_generate(TARGET perf_proto LANGUAGE cpp)
   target_link_libraries(perf_proto PUBLIC protobuf::libprotobuf)
-  
+
 endfunction()
 
 function (config_without_llvm)
@@ -50,8 +50,7 @@ function (config_without_llvm)
     util/symbolize/dwarf2reader.cc
     util/symbolize/dwarf3ranges.cc
     util/symbolize/elf_reader.cc
-    util/symbolize/index_helper.cc
-  )
+    util/symbolize/index_helper.cc)
   target_link_libraries(create_gcov_lib perf_proto)
 
   add_library(quipper_perf OBJECT 
@@ -90,8 +89,7 @@ function (config_without_llvm)
     absl::flags_parse
     create_gcov_lib
     glog
-    quipper_perf
-  )
+    quipper_perf)
 
   add_library(profile_merger_lib OBJECT
     gcov.cc
@@ -101,8 +99,7 @@ function (config_without_llvm)
     profile_reader.cc
     profile_writer.cc
     symbol_map.cc
-    util/symbolize/elf_reader.cc
-  )
+    util/symbolize/elf_reader.cc)
   target_link_libraries(profile_merger_lib perf_proto)
 
   add_executable(profile_merger)
@@ -111,8 +108,7 @@ function (config_without_llvm)
     absl::flags_parse
     profile_merger_lib
     glog
-    quipper_perf
-  )
+    quipper_perf)
 
   add_library(dump_gcov_lib OBJECT
     dump_gcov.cc
@@ -134,7 +130,8 @@ function (config_without_llvm)
 endfunction()
 
 function (config_with_llvm)
-  execute_process(COMMAND sh -c "git -C ${CMAKE_HOME_DIRECTORY}/third_party/llvm-project log -1 --format=%h"
+  execute_process(COMMAND sh -c
+    "git -C ${CMAKE_HOME_DIRECTORY}/third_party/llvm-project log -1 --format=%h"
      RESULT_VARIABLE clang_version_status
      OUTPUT_VARIABLE CLANG_VERSION_OUTPUT)
 
@@ -142,7 +139,8 @@ function (config_with_llvm)
   if (clang_version_status)
      message(WARNING "Could not get clang commit hash : Use clang git hash " ${CLANG_KNOWN_GIT_COMMIT_HASH})
   else()
-     string(REGEX MATCH "([0-9|a-f]+)" CLANG_GIT_COMMIT_HASH ${CLANG_VERSION_OUTPUT})
+     string(REGEX MATCH "([0-9|a-f]+)"
+       CLANG_GIT_COMMIT_HASH ${CLANG_VERSION_OUTPUT})
      if ("${CLANG_GIT_COMMIT_HASH}" STREQUAL ${CLANG_KNOWN_GIT_COMMIT_HASH})
        message(STATUS "Found known git commit hash of clang (" ${CLANG_GIT_COMMIT_HASH} ") - Success")
      else()
@@ -155,9 +153,9 @@ function (config_with_llvm)
   set (LLVM_INCLUDE_TESTS OFF)
   set (LLVM_INCLUDE_TOOLS OFF)
   set (LLVM_INCLUDE_DOCS OFF)
-  
+
   set (LLVM_ENABLE_RTTI ON)
-  set (LLVM_ENABLE_PROJECTS clang CACHE STRING 
+  set (LLVM_ENABLE_PROJECTS clang CACHE STRING
     "Semicolon-separated list of projects to build (${LLVM_KNOWN_PROJECTS}), or \"all\".")
   set (LLVM_TARGETS_TO_BUILD X86 AArch64 CACHE STRING
     "Semicolon-separated list of LLVM targets to build, or \"all\".")
@@ -168,7 +166,7 @@ function (config_with_llvm)
   add_subdirectory(third_party/googletest)
   add_subdirectory(third_party/llvm-project/llvm)
 
-  add_custom_target(exclude_extlib_tests ALL 
+  add_custom_target(exclude_extlib_tests ALL
     COMMAND rm -f ${gtest_BINARY_DIR}/CTestTestfile.cmake
     COMMAND rm -f ${gmock_BINARY_DIR}/CTestTestfile.cmake
     COMMAND rm -f ${googletest-distribution_BINARY_DIR}/CTestTestfile.cmake
@@ -194,7 +192,7 @@ function (config_with_llvm)
   add_library(llvm_propeller_cfg_proto llvm_propeller_cfg.proto)
   protobuf_generate(TARGET llvm_propeller_cfg_proto LANGUAGE cpp)
   target_link_libraries(llvm_propeller_cfg_proto PUBLIC protobuf::libprotobuf)
-  
+
   add_library(llvm_propeller_options_proto llvm_propeller_options.proto)
   target_link_libraries(llvm_propeller_options_proto PUBLIC
     protobuf::libprotobuf)
@@ -202,7 +200,8 @@ function (config_with_llvm)
     TARGET llvm_propeller_options_proto
     LANGUAGE cpp)
   add_library(llvm_propeller_options STATIC llvm_propeller_options_builder.cc)
-  target_link_libraries(llvm_propeller_options quipper_perf llvm_propeller_options_proto)
+  target_link_libraries(llvm_propeller_options
+    quipper_perf llvm_propeller_options_proto)
 
   add_library(mini_disassembler OBJECT mini_disassembler.cc)
   target_link_libraries(mini_disassembler
@@ -214,7 +213,8 @@ function (config_with_llvm)
     LLVMSupport
     LLVMTargetParser)
   foreach (tgt ${LLVM_TARGETS_TO_BUILD})
-    set( tp ${PROJECT_BINARY_DIR}/third_party/llvm-project/llvm/lib/libLLVM${tgt})
+    set(tp
+      ${PROJECT_BINARY_DIR}/third_party/llvm-project/llvm/lib/libLLVM${tgt})
     foreach (tool AsmParser Desc Disassembler Info)
       target_link_libraries(mini_disassembler LLVM${tgt}${tool})
     endforeach()
@@ -222,7 +222,8 @@ function (config_with_llvm)
 
   add_library(sample_reader OBJECT sample_reader.cc spe_sample_reader.cc)
   target_include_directories(sample_reader PUBLIC util)
-  target_link_libraries(sample_reader absl::base quipper_perf perf_proto LLVMObject)
+  target_link_libraries(sample_reader
+    absl::base quipper_perf perf_proto LLVMObject)
   add_dependencies(sample_reader llvm_propeller_objects)
 
   add_library(perfdata_reader OBJECT perfdata_reader.cc)
@@ -326,7 +327,7 @@ function (config_with_llvm)
     LLVMSupport)
 
   add_executable(create_llvm_prof create_llvm_prof.cc)
-  target_link_libraries(create_llvm_prof 
+  target_link_libraries(create_llvm_prof
     absl::base
     absl::check
     absl::flags
@@ -418,7 +419,7 @@ function (config_with_llvm)
     llvm_propeller_binary_address_mapper.cc
     llvm_propeller_binary_content.cc
     llvm_propeller_cfg.cc
-    llvm_propeller_chain_cluster_builder.cc 
+    llvm_propeller_chain_cluster_builder.cc
     llvm_propeller_code_layout.cc
     llvm_propeller_code_layout_scorer.cc
     llvm_propeller_formatting.cc
@@ -444,7 +445,8 @@ function (config_with_llvm)
     status_provider
     LLVMDebugInfoDWARF)
 
-  add_executable(instruction_map_test addr2line.cc instruction_map.cc instruction_map_test.cc)
+  add_executable(instruction_map_test
+    addr2line.cc instruction_map.cc instruction_map_test.cc)
   target_link_libraries(instruction_map_test
     gtest
     gtest_main
@@ -505,7 +507,8 @@ function (config_with_llvm)
     symbol_map)
   add_test(NAME addr2cu_test COMMAND addr2cu_test)
 
-  add_executable(branch_frequencies_autofdo_sample_test branch_frequencies_autofdo_sample_test.cc)
+  add_executable(branch_frequencies_autofdo_sample_test
+    branch_frequencies_autofdo_sample_test.cc)
   target_link_libraries(branch_frequencies_autofdo_sample_test
     gmock
     gtest
@@ -518,7 +521,8 @@ function (config_with_llvm)
     quipper_perf
     status_provider
     symbol_map)
-  add_test(NAME branch_frequencies_autofdo_sample_test COMMAND branch_frequencies_autofdo_sample_test)
+  add_test(NAME branch_frequencies_autofdo_sample_test
+    COMMAND branch_frequencies_autofdo_sample_test)
 
   add_executable(lbr_branch_aggregator_test lbr_branch_aggregator_test.cc)
   target_link_libraries(lbr_branch_aggregator_test
@@ -535,7 +539,8 @@ function (config_with_llvm)
     symbol_map)
   add_test(NAME lbr_branch_aggregator_test COMMAND lbr_branch_aggregator_test)
 
-  add_executable(llvm_propeller_binary_address_mapper_test llvm_propeller_binary_address_mapper_test.cc)
+  add_executable(llvm_propeller_binary_address_mapper_test
+    llvm_propeller_binary_address_mapper_test.cc)
   target_link_libraries(llvm_propeller_binary_address_mapper_test
     gmock
     gtest
@@ -548,7 +553,8 @@ function (config_with_llvm)
     quipper_perf
     status_provider
     symbol_map)
-  add_test(NAME llvm_propeller_binary_address_mapper_test COMMAND llvm_propeller_binary_address_mapper_test)
+  add_test(NAME llvm_propeller_binary_address_mapper_test
+    COMMAND llvm_propeller_binary_address_mapper_test)
 
   add_executable(llvm_propeller_cfg_test llvm_propeller_cfg_test.cc)
   target_link_libraries(llvm_propeller_cfg_test
@@ -566,7 +572,8 @@ function (config_with_llvm)
     symbol_map)
   add_test(NAME llvm_propeller_cfg_test COMMAND llvm_propeller_cfg_test)
 
-  add_executable(llvm_propeller_file_perf_data_provider_test llvm_propeller_file_perf_data_provider_test.cc)
+  add_executable(llvm_propeller_file_perf_data_provider_test
+    llvm_propeller_file_perf_data_provider_test.cc)
   target_link_libraries(llvm_propeller_file_perf_data_provider_test
     gmock
     gtest
@@ -579,9 +586,11 @@ function (config_with_llvm)
     quipper_perf
     status_provider
     symbol_map)
-  add_test(NAME llvm_propeller_file_perf_data_provider_test COMMAND llvm_propeller_file_perf_data_provider_test)
+  add_test(NAME llvm_propeller_file_perf_data_provider_test
+    COMMAND llvm_propeller_file_perf_data_provider_test)
 
-  add_executable(llvm_propeller_perf_branch_frequencies_aggregator_test llvm_propeller_perf_branch_frequencies_aggregator_test.cc)
+  add_executable(llvm_propeller_perf_branch_frequencies_aggregator_test
+    llvm_propeller_perf_branch_frequencies_aggregator_test.cc)
   target_link_libraries(llvm_propeller_perf_branch_frequencies_aggregator_test
     gmock
     gtest
@@ -594,9 +603,11 @@ function (config_with_llvm)
     quipper_perf
     status_provider
     symbol_map)
-  add_test(NAME llvm_propeller_perf_branch_frequencies_aggregator_test COMMAND llvm_propeller_perf_branch_frequencies_aggregator_test)
+  add_test(NAME llvm_propeller_perf_branch_frequencies_aggregator_test
+    COMMAND llvm_propeller_perf_branch_frequencies_aggregator_test)
 
-  add_executable(llvm_propeller_perf_lbr_aggregator_test llvm_propeller_perf_lbr_aggregator_test.cc)
+  add_executable(llvm_propeller_perf_lbr_aggregator_test
+    llvm_propeller_perf_lbr_aggregator_test.cc)
   target_link_libraries(llvm_propeller_perf_lbr_aggregator_test
     gtest_main
     llvm_profile_writer
@@ -607,9 +618,11 @@ function (config_with_llvm)
     quipper_perf
     status_provider
     symbol_map)
-  add_test(NAME llvm_propeller_perf_lbr_aggregator_test COMMAND llvm_propeller_perf_lbr_aggregator_test)
+  add_test(NAME llvm_propeller_perf_lbr_aggregator_test
+    COMMAND llvm_propeller_perf_lbr_aggregator_test)
 
-  add_executable(llvm_propeller_profile_computer_test llvm_propeller_profile_computer_test.cc)
+  add_executable(llvm_propeller_profile_computer_test
+    llvm_propeller_profile_computer_test.cc)
   target_link_libraries(llvm_propeller_profile_computer_test
     gmock
     gtest
@@ -622,9 +635,11 @@ function (config_with_llvm)
     quipper_perf
     status_provider
     symbol_map)
-  add_test(NAME llvm_propeller_profile_computer_test COMMAND llvm_propeller_profile_computer_test)
+  add_test(NAME llvm_propeller_profile_computer_test
+    COMMAND llvm_propeller_profile_computer_test)
 
-  add_executable(llvm_propeller_profile_generator_test llvm_propeller_profile_generator_test.cc)
+  add_executable(llvm_propeller_profile_generator_test
+    llvm_propeller_profile_generator_test.cc)
   target_link_libraries(llvm_propeller_profile_generator_test
     gmock
     gtest
@@ -637,9 +652,11 @@ function (config_with_llvm)
     quipper_perf
     status_provider
     symbol_map)
-  add_test(NAME llvm_propeller_profile_generator_test COMMAND llvm_propeller_profile_generator_test)
+  add_test(NAME llvm_propeller_profile_generator_test
+    COMMAND llvm_propeller_profile_generator_test)
 
-  add_executable(llvm_propeller_program_cfg_builder_test llvm_propeller_program_cfg_builder_test.cc)
+  add_executable(llvm_propeller_program_cfg_builder_test
+    llvm_propeller_program_cfg_builder_test.cc)
   target_link_libraries(llvm_propeller_program_cfg_builder_test
     gmock
     gtest
@@ -652,9 +669,11 @@ function (config_with_llvm)
     quipper_perf
     status_provider
     symbol_map)
-  add_test(NAME llvm_propeller_program_cfg_builder_test COMMAND llvm_propeller_program_cfg_builder_test)
+  add_test(NAME llvm_propeller_program_cfg_builder_test
+    COMMAND llvm_propeller_program_cfg_builder_test)
 
-  add_executable(llvm_propeller_program_cfg_proto_builder_test llvm_propeller_program_cfg_proto_builder_test.cc)
+  add_executable(llvm_propeller_program_cfg_proto_builder_test
+    llvm_propeller_program_cfg_proto_builder_test.cc)
   target_link_libraries(llvm_propeller_program_cfg_proto_builder_test
     gtest
     gtest_main
@@ -666,9 +685,11 @@ function (config_with_llvm)
     quipper_perf
     status_provider
     symbol_map)
-  add_test(NAME llvm_propeller_program_cfg_proto_builder_test COMMAND llvm_propeller_program_cfg_proto_builder_test)
+  add_test(NAME llvm_propeller_program_cfg_proto_builder_test
+    COMMAND llvm_propeller_program_cfg_proto_builder_test)
 
-  add_executable(llvm_propeller_program_cfg_test llvm_propeller_program_cfg_test.cc)
+  add_executable(llvm_propeller_program_cfg_test
+    llvm_propeller_program_cfg_test.cc)
   target_link_libraries(llvm_propeller_program_cfg_test
     gmock
     gtest
@@ -682,9 +703,11 @@ function (config_with_llvm)
     quipper_perf
     status_provider
     symbol_map)
-  add_test(NAME llvm_propeller_program_cfg_test COMMAND llvm_propeller_program_cfg_test)
+  add_test(NAME llvm_propeller_program_cfg_test
+    COMMAND llvm_propeller_program_cfg_test)
 
-  add_executable(llvm_propeller_statistics_test llvm_propeller_statistics_test.cc)
+  add_executable(llvm_propeller_statistics_test
+    llvm_propeller_statistics_test.cc)
   target_link_libraries(llvm_propeller_statistics_test
     gtest
     gtest_main
@@ -696,7 +719,8 @@ function (config_with_llvm)
     quipper_perf
     status_provider
     symbol_map)
-  add_test(NAME llvm_propeller_statistics_test COMMAND llvm_propeller_statistics_test)
+  add_test(NAME llvm_propeller_statistics_test
+    COMMAND llvm_propeller_statistics_test)
 
   add_executable(perfdata_reader_test perfdata_reader_test.cc)
   target_link_libraries(perfdata_reader_test
@@ -728,7 +752,8 @@ function (config_with_llvm)
     symbol_map)
   add_test(NAME spe_sample_reader_test COMMAND spe_sample_reader_test)
 
-  add_executable(llvm_propeller_code_layout_test llvm_propeller_code_layout_test.cc)
+  add_executable(llvm_propeller_code_layout_test
+    llvm_propeller_code_layout_test.cc)
   target_link_libraries(llvm_propeller_code_layout_test
     gmock
     gtest
@@ -742,12 +767,13 @@ function (config_with_llvm)
     quipper_perf
     status_provider
     symbol_map)
-  add_test(NAME llvm_propeller_code_layout_test COMMAND llvm_propeller_code_layout_test)
+  add_test(NAME llvm_propeller_code_layout_test
+    COMMAND llvm_propeller_code_layout_test)
 
   add_library(llvm_propeller_cfg OBJECT llvm_propeller_cfg.cc)
   add_library(llvm_propeller_formatting OBJECT llvm_propeller_formatting.cc)
 
-  add_library(quipper_perf OBJECT 
+  add_library(quipper_perf OBJECT
     third_party/perf_data_converter/src/quipper/address_mapper.cc
     third_party/perf_data_converter/src/quipper/arm_spe_decoder.cc
     third_party/perf_data_converter/src/quipper/base/logging.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,7 @@ function (config_with_llvm)
     "Semicolon-separated list of projects to build (${LLVM_KNOWN_PROJECTS}), or \"all\".")
   set (LLVM_TARGETS_TO_BUILD X86 AArch64 CACHE STRING
     "Semicolon-separated list of LLVM targets to build, or \"all\".")
+  set (LLVM_ENABLE_ZSTD, FORCE_ON)
   ###
 
   add_subdirectory(third_party/abseil)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ function (execute_perf_protobuf)
     third_party/perf_data_converter/src/quipper/perf_stat.proto)
   protobuf_generate(TARGET perf_proto LANGUAGE cpp)
   target_link_libraries(perf_proto PUBLIC protobuf::libprotobuf)
-
+  
 endfunction()
 
 function (config_without_llvm)
@@ -50,7 +50,8 @@ function (config_without_llvm)
     util/symbolize/dwarf2reader.cc
     util/symbolize/dwarf3ranges.cc
     util/symbolize/elf_reader.cc
-    util/symbolize/index_helper.cc)
+    util/symbolize/index_helper.cc
+  )
   target_link_libraries(create_gcov_lib perf_proto)
 
   add_library(quipper_perf OBJECT 
@@ -89,7 +90,8 @@ function (config_without_llvm)
     absl::flags_parse
     create_gcov_lib
     glog
-    quipper_perf)
+    quipper_perf
+  )
 
   add_library(profile_merger_lib OBJECT
     gcov.cc
@@ -99,7 +101,8 @@ function (config_without_llvm)
     profile_reader.cc
     profile_writer.cc
     symbol_map.cc
-    util/symbolize/elf_reader.cc)
+    util/symbolize/elf_reader.cc
+  )
   target_link_libraries(profile_merger_lib perf_proto)
 
   add_executable(profile_merger)
@@ -108,7 +111,8 @@ function (config_without_llvm)
     absl::flags_parse
     profile_merger_lib
     glog
-    quipper_perf)
+    quipper_perf
+  )
 
   add_library(dump_gcov_lib OBJECT
     dump_gcov.cc
@@ -130,8 +134,7 @@ function (config_without_llvm)
 endfunction()
 
 function (config_with_llvm)
-  execute_process(COMMAND sh -c
-    "git -C ${CMAKE_HOME_DIRECTORY}/third_party/llvm-project log -1 --format=%h"
+  execute_process(COMMAND sh -c "git -C ${CMAKE_HOME_DIRECTORY}/third_party/llvm-project log -1 --format=%h"
      RESULT_VARIABLE clang_version_status
      OUTPUT_VARIABLE CLANG_VERSION_OUTPUT)
 
@@ -139,8 +142,7 @@ function (config_with_llvm)
   if (clang_version_status)
      message(WARNING "Could not get clang commit hash : Use clang git hash " ${CLANG_KNOWN_GIT_COMMIT_HASH})
   else()
-     string(REGEX MATCH "([0-9|a-f]+)"
-       CLANG_GIT_COMMIT_HASH ${CLANG_VERSION_OUTPUT})
+     string(REGEX MATCH "([0-9|a-f]+)" CLANG_GIT_COMMIT_HASH ${CLANG_VERSION_OUTPUT})
      if ("${CLANG_GIT_COMMIT_HASH}" STREQUAL ${CLANG_KNOWN_GIT_COMMIT_HASH})
        message(STATUS "Found known git commit hash of clang (" ${CLANG_GIT_COMMIT_HASH} ") - Success")
      else()
@@ -153,9 +155,9 @@ function (config_with_llvm)
   set (LLVM_INCLUDE_TESTS OFF)
   set (LLVM_INCLUDE_TOOLS OFF)
   set (LLVM_INCLUDE_DOCS OFF)
-
+  
   set (LLVM_ENABLE_RTTI ON)
-  set (LLVM_ENABLE_PROJECTS clang CACHE STRING
+  set (LLVM_ENABLE_PROJECTS clang CACHE STRING 
     "Semicolon-separated list of projects to build (${LLVM_KNOWN_PROJECTS}), or \"all\".")
   set (LLVM_TARGETS_TO_BUILD X86 AArch64 CACHE STRING
     "Semicolon-separated list of LLVM targets to build, or \"all\".")
@@ -167,7 +169,7 @@ function (config_with_llvm)
   add_subdirectory(third_party/googletest)
   add_subdirectory(third_party/llvm-project/llvm)
 
-  add_custom_target(exclude_extlib_tests ALL
+  add_custom_target(exclude_extlib_tests ALL 
     COMMAND rm -f ${gtest_BINARY_DIR}/CTestTestfile.cmake
     COMMAND rm -f ${gmock_BINARY_DIR}/CTestTestfile.cmake
     COMMAND rm -f ${googletest-distribution_BINARY_DIR}/CTestTestfile.cmake
@@ -193,7 +195,7 @@ function (config_with_llvm)
   add_library(llvm_propeller_cfg_proto llvm_propeller_cfg.proto)
   protobuf_generate(TARGET llvm_propeller_cfg_proto LANGUAGE cpp)
   target_link_libraries(llvm_propeller_cfg_proto PUBLIC protobuf::libprotobuf)
-
+  
   add_library(llvm_propeller_options_proto llvm_propeller_options.proto)
   target_link_libraries(llvm_propeller_options_proto PUBLIC
     protobuf::libprotobuf)
@@ -201,8 +203,7 @@ function (config_with_llvm)
     TARGET llvm_propeller_options_proto
     LANGUAGE cpp)
   add_library(llvm_propeller_options STATIC llvm_propeller_options_builder.cc)
-  target_link_libraries(llvm_propeller_options
-    quipper_perf llvm_propeller_options_proto)
+  target_link_libraries(llvm_propeller_options quipper_perf llvm_propeller_options_proto)
 
   add_library(mini_disassembler OBJECT mini_disassembler.cc)
   target_link_libraries(mini_disassembler
@@ -214,8 +215,7 @@ function (config_with_llvm)
     LLVMSupport
     LLVMTargetParser)
   foreach (tgt ${LLVM_TARGETS_TO_BUILD})
-    set(tp
-      ${PROJECT_BINARY_DIR}/third_party/llvm-project/llvm/lib/libLLVM${tgt})
+    set( tp ${PROJECT_BINARY_DIR}/third_party/llvm-project/llvm/lib/libLLVM${tgt})
     foreach (tool AsmParser Desc Disassembler Info)
       target_link_libraries(mini_disassembler LLVM${tgt}${tool})
     endforeach()
@@ -223,8 +223,7 @@ function (config_with_llvm)
 
   add_library(sample_reader OBJECT sample_reader.cc spe_sample_reader.cc)
   target_include_directories(sample_reader PUBLIC util)
-  target_link_libraries(sample_reader
-    absl::base quipper_perf perf_proto LLVMObject)
+  target_link_libraries(sample_reader absl::base quipper_perf perf_proto LLVMObject)
   add_dependencies(sample_reader llvm_propeller_objects)
 
   add_library(perfdata_reader OBJECT perfdata_reader.cc)
@@ -328,7 +327,7 @@ function (config_with_llvm)
     LLVMSupport)
 
   add_executable(create_llvm_prof create_llvm_prof.cc)
-  target_link_libraries(create_llvm_prof
+  target_link_libraries(create_llvm_prof 
     absl::base
     absl::check
     absl::flags
@@ -420,7 +419,7 @@ function (config_with_llvm)
     llvm_propeller_binary_address_mapper.cc
     llvm_propeller_binary_content.cc
     llvm_propeller_cfg.cc
-    llvm_propeller_chain_cluster_builder.cc
+    llvm_propeller_chain_cluster_builder.cc 
     llvm_propeller_code_layout.cc
     llvm_propeller_code_layout_scorer.cc
     llvm_propeller_formatting.cc
@@ -446,8 +445,7 @@ function (config_with_llvm)
     status_provider
     LLVMDebugInfoDWARF)
 
-  add_executable(instruction_map_test
-    addr2line.cc instruction_map.cc instruction_map_test.cc)
+  add_executable(instruction_map_test addr2line.cc instruction_map.cc instruction_map_test.cc)
   target_link_libraries(instruction_map_test
     gtest
     gtest_main
@@ -508,8 +506,7 @@ function (config_with_llvm)
     symbol_map)
   add_test(NAME addr2cu_test COMMAND addr2cu_test)
 
-  add_executable(branch_frequencies_autofdo_sample_test
-    branch_frequencies_autofdo_sample_test.cc)
+  add_executable(branch_frequencies_autofdo_sample_test branch_frequencies_autofdo_sample_test.cc)
   target_link_libraries(branch_frequencies_autofdo_sample_test
     gmock
     gtest
@@ -522,8 +519,7 @@ function (config_with_llvm)
     quipper_perf
     status_provider
     symbol_map)
-  add_test(NAME branch_frequencies_autofdo_sample_test
-    COMMAND branch_frequencies_autofdo_sample_test)
+  add_test(NAME branch_frequencies_autofdo_sample_test COMMAND branch_frequencies_autofdo_sample_test)
 
   add_executable(lbr_branch_aggregator_test lbr_branch_aggregator_test.cc)
   target_link_libraries(lbr_branch_aggregator_test
@@ -540,8 +536,7 @@ function (config_with_llvm)
     symbol_map)
   add_test(NAME lbr_branch_aggregator_test COMMAND lbr_branch_aggregator_test)
 
-  add_executable(llvm_propeller_binary_address_mapper_test
-    llvm_propeller_binary_address_mapper_test.cc)
+  add_executable(llvm_propeller_binary_address_mapper_test llvm_propeller_binary_address_mapper_test.cc)
   target_link_libraries(llvm_propeller_binary_address_mapper_test
     gmock
     gtest
@@ -554,8 +549,7 @@ function (config_with_llvm)
     quipper_perf
     status_provider
     symbol_map)
-  add_test(NAME llvm_propeller_binary_address_mapper_test
-    COMMAND llvm_propeller_binary_address_mapper_test)
+  add_test(NAME llvm_propeller_binary_address_mapper_test COMMAND llvm_propeller_binary_address_mapper_test)
 
   add_executable(llvm_propeller_cfg_test llvm_propeller_cfg_test.cc)
   target_link_libraries(llvm_propeller_cfg_test
@@ -573,8 +567,7 @@ function (config_with_llvm)
     symbol_map)
   add_test(NAME llvm_propeller_cfg_test COMMAND llvm_propeller_cfg_test)
 
-  add_executable(llvm_propeller_file_perf_data_provider_test
-    llvm_propeller_file_perf_data_provider_test.cc)
+  add_executable(llvm_propeller_file_perf_data_provider_test llvm_propeller_file_perf_data_provider_test.cc)
   target_link_libraries(llvm_propeller_file_perf_data_provider_test
     gmock
     gtest
@@ -587,11 +580,9 @@ function (config_with_llvm)
     quipper_perf
     status_provider
     symbol_map)
-  add_test(NAME llvm_propeller_file_perf_data_provider_test
-    COMMAND llvm_propeller_file_perf_data_provider_test)
+  add_test(NAME llvm_propeller_file_perf_data_provider_test COMMAND llvm_propeller_file_perf_data_provider_test)
 
-  add_executable(llvm_propeller_perf_branch_frequencies_aggregator_test
-    llvm_propeller_perf_branch_frequencies_aggregator_test.cc)
+  add_executable(llvm_propeller_perf_branch_frequencies_aggregator_test llvm_propeller_perf_branch_frequencies_aggregator_test.cc)
   target_link_libraries(llvm_propeller_perf_branch_frequencies_aggregator_test
     gmock
     gtest
@@ -604,11 +595,9 @@ function (config_with_llvm)
     quipper_perf
     status_provider
     symbol_map)
-  add_test(NAME llvm_propeller_perf_branch_frequencies_aggregator_test
-    COMMAND llvm_propeller_perf_branch_frequencies_aggregator_test)
+  add_test(NAME llvm_propeller_perf_branch_frequencies_aggregator_test COMMAND llvm_propeller_perf_branch_frequencies_aggregator_test)
 
-  add_executable(llvm_propeller_perf_lbr_aggregator_test
-    llvm_propeller_perf_lbr_aggregator_test.cc)
+  add_executable(llvm_propeller_perf_lbr_aggregator_test llvm_propeller_perf_lbr_aggregator_test.cc)
   target_link_libraries(llvm_propeller_perf_lbr_aggregator_test
     gtest_main
     llvm_profile_writer
@@ -619,11 +608,9 @@ function (config_with_llvm)
     quipper_perf
     status_provider
     symbol_map)
-  add_test(NAME llvm_propeller_perf_lbr_aggregator_test
-    COMMAND llvm_propeller_perf_lbr_aggregator_test)
+  add_test(NAME llvm_propeller_perf_lbr_aggregator_test COMMAND llvm_propeller_perf_lbr_aggregator_test)
 
-  add_executable(llvm_propeller_profile_computer_test
-    llvm_propeller_profile_computer_test.cc)
+  add_executable(llvm_propeller_profile_computer_test llvm_propeller_profile_computer_test.cc)
   target_link_libraries(llvm_propeller_profile_computer_test
     gmock
     gtest
@@ -636,11 +623,9 @@ function (config_with_llvm)
     quipper_perf
     status_provider
     symbol_map)
-  add_test(NAME llvm_propeller_profile_computer_test
-    COMMAND llvm_propeller_profile_computer_test)
+  add_test(NAME llvm_propeller_profile_computer_test COMMAND llvm_propeller_profile_computer_test)
 
-  add_executable(llvm_propeller_profile_generator_test
-    llvm_propeller_profile_generator_test.cc)
+  add_executable(llvm_propeller_profile_generator_test llvm_propeller_profile_generator_test.cc)
   target_link_libraries(llvm_propeller_profile_generator_test
     gmock
     gtest
@@ -653,11 +638,9 @@ function (config_with_llvm)
     quipper_perf
     status_provider
     symbol_map)
-  add_test(NAME llvm_propeller_profile_generator_test
-    COMMAND llvm_propeller_profile_generator_test)
+  add_test(NAME llvm_propeller_profile_generator_test COMMAND llvm_propeller_profile_generator_test)
 
-  add_executable(llvm_propeller_program_cfg_builder_test
-    llvm_propeller_program_cfg_builder_test.cc)
+  add_executable(llvm_propeller_program_cfg_builder_test llvm_propeller_program_cfg_builder_test.cc)
   target_link_libraries(llvm_propeller_program_cfg_builder_test
     gmock
     gtest
@@ -670,11 +653,9 @@ function (config_with_llvm)
     quipper_perf
     status_provider
     symbol_map)
-  add_test(NAME llvm_propeller_program_cfg_builder_test
-    COMMAND llvm_propeller_program_cfg_builder_test)
+  add_test(NAME llvm_propeller_program_cfg_builder_test COMMAND llvm_propeller_program_cfg_builder_test)
 
-  add_executable(llvm_propeller_program_cfg_proto_builder_test
-    llvm_propeller_program_cfg_proto_builder_test.cc)
+  add_executable(llvm_propeller_program_cfg_proto_builder_test llvm_propeller_program_cfg_proto_builder_test.cc)
   target_link_libraries(llvm_propeller_program_cfg_proto_builder_test
     gtest
     gtest_main
@@ -686,11 +667,9 @@ function (config_with_llvm)
     quipper_perf
     status_provider
     symbol_map)
-  add_test(NAME llvm_propeller_program_cfg_proto_builder_test
-    COMMAND llvm_propeller_program_cfg_proto_builder_test)
+  add_test(NAME llvm_propeller_program_cfg_proto_builder_test COMMAND llvm_propeller_program_cfg_proto_builder_test)
 
-  add_executable(llvm_propeller_program_cfg_test
-    llvm_propeller_program_cfg_test.cc)
+  add_executable(llvm_propeller_program_cfg_test llvm_propeller_program_cfg_test.cc)
   target_link_libraries(llvm_propeller_program_cfg_test
     gmock
     gtest
@@ -704,11 +683,9 @@ function (config_with_llvm)
     quipper_perf
     status_provider
     symbol_map)
-  add_test(NAME llvm_propeller_program_cfg_test
-    COMMAND llvm_propeller_program_cfg_test)
+  add_test(NAME llvm_propeller_program_cfg_test COMMAND llvm_propeller_program_cfg_test)
 
-  add_executable(llvm_propeller_statistics_test
-    llvm_propeller_statistics_test.cc)
+  add_executable(llvm_propeller_statistics_test llvm_propeller_statistics_test.cc)
   target_link_libraries(llvm_propeller_statistics_test
     gtest
     gtest_main
@@ -720,8 +697,7 @@ function (config_with_llvm)
     quipper_perf
     status_provider
     symbol_map)
-  add_test(NAME llvm_propeller_statistics_test
-    COMMAND llvm_propeller_statistics_test)
+  add_test(NAME llvm_propeller_statistics_test COMMAND llvm_propeller_statistics_test)
 
   add_executable(perfdata_reader_test perfdata_reader_test.cc)
   target_link_libraries(perfdata_reader_test
@@ -753,8 +729,7 @@ function (config_with_llvm)
     symbol_map)
   add_test(NAME spe_sample_reader_test COMMAND spe_sample_reader_test)
 
-  add_executable(llvm_propeller_code_layout_test
-    llvm_propeller_code_layout_test.cc)
+  add_executable(llvm_propeller_code_layout_test llvm_propeller_code_layout_test.cc)
   target_link_libraries(llvm_propeller_code_layout_test
     gmock
     gtest
@@ -768,13 +743,12 @@ function (config_with_llvm)
     quipper_perf
     status_provider
     symbol_map)
-  add_test(NAME llvm_propeller_code_layout_test
-    COMMAND llvm_propeller_code_layout_test)
+  add_test(NAME llvm_propeller_code_layout_test COMMAND llvm_propeller_code_layout_test)
 
   add_library(llvm_propeller_cfg OBJECT llvm_propeller_cfg.cc)
   add_library(llvm_propeller_formatting OBJECT llvm_propeller_formatting.cc)
 
-  add_library(quipper_perf OBJECT
+  add_library(quipper_perf OBJECT 
     third_party/perf_data_converter/src/quipper/address_mapper.cc
     third_party/perf_data_converter/src/quipper/arm_spe_decoder.cc
     third_party/perf_data_converter/src/quipper/base/logging.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,135 @@ set(ABSL_PROPAGATE_CXX_STD on)
 
 project(autofdo)
 
+function (execute_perf_protobuf)
+
+  find_package(Protobuf REQUIRED)
+
+  add_library(perf_proto
+    third_party/perf_data_converter/src/quipper/perf_data.proto
+    third_party/perf_data_converter/src/quipper/perf_parser_options.proto
+    third_party/perf_data_converter/src/quipper/perf_stat.proto)
+  protobuf_generate(TARGET perf_proto LANGUAGE cpp)
+  target_link_libraries(perf_proto PUBLIC protobuf::libprotobuf)
+  
+endfunction()
+
+function (config_without_llvm)
+  add_subdirectory(third_party/abseil)
+  add_subdirectory(third_party/glog)
+
+  include_directories(${CMAKE_HOME_DIRECTORY}
+    third_party/glog/src
+    third_party/abseil
+    third_party/perf_data_converter/src
+    third_party/perf_data_converter/src/quipper
+    util
+    ${PROJECT_BINARY_DIR}
+    ${PROJECT_BINARY_DIR}/third_party/glog
+    ${PROJECT_BINARY_DIR}/third_party/perf_data_converter/src/quipper)
+
+  find_library (LIBELF_LIBRARIES NAMES elf REQUIRED)
+  find_library (LIBCRYPTO_LIBRARIES NAMES crypto REQUIRED)
+
+  add_library(create_gcov_lib OBJECT
+    create_gcov.cc
+    gcov.cc
+    instruction_map.cc
+    legacy_addr2line.cc
+    profile.cc
+    profile_creator.cc
+    profile_writer.cc
+    sample_reader.cc
+    symbol_map.cc
+    util/symbolize/addr2line_inlinestack.cc
+    util/symbolize/bytereader.cc
+    util/symbolize/functioninfo.cc
+    util/symbolize/dwarf2reader.cc
+    util/symbolize/dwarf3ranges.cc
+    util/symbolize/elf_reader.cc
+    util/symbolize/index_helper.cc
+  )
+  target_link_libraries(create_gcov_lib perf_proto)
+
+  add_library(quipper_perf OBJECT 
+    third_party/perf_data_converter/src/quipper/address_mapper.cc
+    third_party/perf_data_converter/src/quipper/base/logging.cc
+    third_party/perf_data_converter/src/quipper/binary_data_utils.cc
+    third_party/perf_data_converter/src/quipper/binary_data_utils.cc
+    third_party/perf_data_converter/src/quipper/buffer_reader.cc
+    third_party/perf_data_converter/src/quipper/buffer_writer.cc
+    third_party/perf_data_converter/src/quipper/compat/log_level.cc
+    third_party/perf_data_converter/src/quipper/data_reader.cc
+    third_party/perf_data_converter/src/quipper/data_writer.cc
+    third_party/perf_data_converter/src/quipper/dso.cc
+    third_party/perf_data_converter/src/quipper/file_reader.cc
+    third_party/perf_data_converter/src/quipper/file_utils.cc
+    third_party/perf_data_converter/src/quipper/huge_page_deducer.cc
+    third_party/perf_data_converter/src/quipper/perf_buildid.cc
+    third_party/perf_data_converter/src/quipper/perf_data_utils.cc
+    third_party/perf_data_converter/src/quipper/perf_serializer.cc
+    third_party/perf_data_converter/src/quipper/perf_reader.cc
+    third_party/perf_data_converter/src/quipper/perf_parser.cc
+    third_party/perf_data_converter/src/quipper/sample_info_reader.cc
+    third_party/perf_data_converter/src/quipper/string_utils.cc)
+  target_include_directories(quipper_perf PRIVATE
+    third_party/abseil)
+  target_include_directories(quipper_perf BEFORE
+    PUBLIC
+    third_party/perf_data_converter/src
+    third_party/perf_data_converter/src/quipper)
+  target_link_libraries(quipper_perf
+    perf_proto ${Protobuf_LIBRARIES} ${LIBELF_LIBRARIES} ${LIBCRYPTO_LIBRARIES})
+
+  add_executable(create_gcov)
+  target_link_libraries(create_gcov
+    absl::flags
+    absl::flags_parse
+    create_gcov_lib
+    glog
+    quipper_perf
+  )
+
+  add_library(profile_merger_lib OBJECT
+    gcov.cc
+    instruction_map.cc
+    profile_merger.cc
+    profile.cc
+    profile_reader.cc
+    profile_writer.cc
+    symbol_map.cc
+    util/symbolize/elf_reader.cc
+  )
+  target_link_libraries(profile_merger_lib perf_proto)
+
+  add_executable(profile_merger)
+  target_link_libraries(profile_merger
+    absl::flags
+    absl::flags_parse
+    profile_merger_lib
+    glog
+    quipper_perf
+  )
+
+  add_library(dump_gcov_lib OBJECT
+    dump_gcov.cc
+    gcov.cc
+    instruction_map.cc
+    profile.cc
+    profile_reader.cc
+    symbol_map.cc
+    util/symbolize/elf_reader.cc)
+  target_link_libraries(dump_gcov_lib perf_proto)
+
+  add_executable(dump_gcov)
+  target_link_libraries(dump_gcov
+    absl::flags
+    absl::flags_parse
+    dump_gcov_lib
+    glog)
+
+endfunction()
+
 function (config_with_llvm)
   execute_process(COMMAND sh -c "git -C ${CMAKE_HOME_DIRECTORY}/third_party/llvm-project log -1 --format=%h"
      RESULT_VARIABLE clang_version_status
@@ -61,15 +190,6 @@ function (config_with_llvm)
     third_party/perf_data_converter/src
     third_party/perf_data_converter/src/quipper
     util/regexp)
-
-  find_package(Protobuf REQUIRED)
-
-  add_library(perf_proto
-    third_party/perf_data_converter/src/quipper/perf_data.proto
-    third_party/perf_data_converter/src/quipper/perf_parser_options.proto
-    third_party/perf_data_converter/src/quipper/perf_stat.proto)
-  protobuf_generate(TARGET perf_proto LANGUAGE cpp)
-  target_link_libraries(perf_proto PUBLIC protobuf::libprotobuf)
 
   add_library(llvm_propeller_cfg_proto llvm_propeller_cfg.proto)
   protobuf_generate(TARGET llvm_propeller_cfg_proto LANGUAGE cpp)
@@ -667,5 +787,10 @@ function (config_with_llvm)
     DEPENDS prepare_cmds)
 endfunction()
 
-config_with_llvm()
+execute_perf_protobuf()
+if (DEFINED WITH_LLVM)
+  config_with_llvm()
+else ()
+  config_without_llvm()
+endif ()
 enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,7 +159,7 @@ function (config_with_llvm)
     "Semicolon-separated list of projects to build (${LLVM_KNOWN_PROJECTS}), or \"all\".")
   set (LLVM_TARGETS_TO_BUILD X86 AArch64 CACHE STRING
     "Semicolon-separated list of LLVM targets to build, or \"all\".")
-  set (LLVM_ENABLE_ZSTD, FORCE_ON)
+  set (LLVM_ENABLE_ZSTD FORCE_ON)
   ###
 
   add_subdirectory(third_party/abseil)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,141 +4,6 @@ set(ABSL_PROPAGATE_CXX_STD on)
 
 project(autofdo)
 
-function (config_without_llvm)
-  add_subdirectory(third_party/abseil)
-  add_subdirectory(third_party/glog)
-
-  include_directories(${CMAKE_HOME_DIRECTORY}
-    third_party/glog/src
-    third_party/abseil
-    third_party/perf_data_converter/src
-    third_party/perf_data_converter/src/quipper
-    util
-    ${PROJECT_BINARY_DIR}
-    ${PROJECT_BINARY_DIR}/third_party/glog)
-
-  find_library (LIBELF_LIBRARIES NAMES elf REQUIRED)
-  find_library (LIBCRYPTO_LIBRARIES NAMES crypto REQUIRED)
-
-  find_package(Protobuf REQUIRED)
-  protobuf_generate_cpp(PERF_DATA_PROTO_CC PERF_DATA_PROTO_HDR third_party/perf_data_converter/src/quipper/perf_data.proto)
-  protobuf_generate_cpp(PERF_PARSER_OPTIONS_CC PERF_PARSER_OPTIONS_HDR third_party/perf_data_converter/src/quipper/perf_parser_options.proto)
-  protobuf_generate_cpp(PERF_STAT_CC PERF_STAT_HDR third_party/perf_data_converter/src/quipper/perf_stat.proto)
-  add_library(perf_data_proto OBJECT ${PERF_DATA_PROTO_CC})
-  add_library(perf_parser_options_proto OBJECT ${PERF_PARSER_OPTIONS_CC})
-  add_library(perf_stat_proto OBJECT ${PERF_STAT_CC})
-
-  add_library(create_gcov_lib OBJECT
-    create_gcov.cc
-    gcov.cc
-    instruction_map.cc
-    legacy_addr2line.cc
-    profile.cc
-    profile_creator.cc
-    profile_writer.cc
-    sample_reader.cc
-    symbol_map.cc
-    util/symbolize/addr2line_inlinestack.cc
-    util/symbolize/bytereader.cc
-    util/symbolize/functioninfo.cc
-    util/symbolize/dwarf2reader.cc
-    util/symbolize/dwarf3ranges.cc
-    util/symbolize/elf_reader.cc
-    util/symbolize/index_helper.cc
-  )
-  add_dependencies(create_gcov_lib perf_data_proto)
-  add_dependencies(create_gcov_lib perf_parser_options_proto)
-  add_dependencies(create_gcov_lib perf_stat_proto)
-
-  add_library(quipper_perf OBJECT 
-    third_party/perf_data_converter/src/quipper/address_mapper.cc
-    third_party/perf_data_converter/src/quipper/base/logging.cc
-    third_party/perf_data_converter/src/quipper/binary_data_utils.cc
-    third_party/perf_data_converter/src/quipper/binary_data_utils.cc
-    third_party/perf_data_converter/src/quipper/buffer_reader.cc
-    third_party/perf_data_converter/src/quipper/buffer_writer.cc
-    third_party/perf_data_converter/src/quipper/compat/log_level.cc
-    third_party/perf_data_converter/src/quipper/data_reader.cc
-    third_party/perf_data_converter/src/quipper/data_writer.cc
-    third_party/perf_data_converter/src/quipper/dso.cc
-    third_party/perf_data_converter/src/quipper/file_reader.cc
-    third_party/perf_data_converter/src/quipper/file_utils.cc
-    third_party/perf_data_converter/src/quipper/huge_page_deducer.cc
-    third_party/perf_data_converter/src/quipper/perf_buildid.cc
-    third_party/perf_data_converter/src/quipper/perf_data_utils.cc
-    third_party/perf_data_converter/src/quipper/perf_serializer.cc
-    third_party/perf_data_converter/src/quipper/perf_reader.cc
-    third_party/perf_data_converter/src/quipper/perf_parser.cc
-    third_party/perf_data_converter/src/quipper/sample_info_reader.cc
-    third_party/perf_data_converter/src/quipper/string_utils.cc
-    ${PERF_DATA_PROTO_HDR}
-    ${PERF_DATA_PROTO_CC}
-    ${PERF_PARSER_OPTIONS_HDR}
-    ${PERF_PARSER_OPTIONS_CC}
-    ${PERF_STAT_CC}
-    ${PERF_STAT_HDR})
-  target_include_directories(quipper_perf PRIVATE
-    third_party/abseil)
-  target_include_directories(quipper_perf BEFORE
-    PUBLIC
-    third_party/perf_data_converter/src
-    third_party/perf_data_converter/src/quipper)
-  target_link_libraries(quipper_perf ${Protobuf_LIBRARIES} ${LIBELF_LIBRARIES} ${LIBCRYPTO_LIBRARIES})
-
-  add_executable(create_gcov)
-  target_link_libraries(create_gcov
-    absl::flags
-    absl::flags_parse
-    create_gcov_lib
-    glog
-    quipper_perf
-  )
-
-  add_library(profile_merger_lib OBJECT
-    gcov.cc
-    instruction_map.cc
-    profile_merger.cc
-    profile.cc
-    profile_reader.cc
-    profile_writer.cc
-    symbol_map.cc
-    util/symbolize/elf_reader.cc
-  )
-  add_dependencies(profile_merger_lib perf_data_proto)
-  add_dependencies(profile_merger_lib perf_parser_options_proto)
-  add_dependencies(profile_merger_lib perf_stat_proto)
-
-  add_executable(profile_merger)
-  target_link_libraries(profile_merger
-    absl::flags
-    absl::flags_parse
-    profile_merger_lib
-    glog
-    quipper_perf
-  )
-
-  add_library(dump_gcov_lib OBJECT
-    dump_gcov.cc
-    gcov.cc
-    instruction_map.cc
-    profile.cc
-    profile_reader.cc
-    symbol_map.cc
-    util/symbolize/elf_reader.cc
-  )
-  add_dependencies(dump_gcov_lib perf_data_proto)
-  add_dependencies(dump_gcov_lib perf_parser_options_proto)
-  add_dependencies(dump_gcov_lib perf_stat_proto)
-
-  add_executable(dump_gcov)
-  target_link_libraries(dump_gcov
-    absl::flags
-    absl::flags_parse
-    dump_gcov_lib
-    glog
-  )
-endfunction ()
-
 function (config_with_llvm)
   execute_process(COMMAND sh -c "git -C ${CMAKE_HOME_DIRECTORY}/third_party/llvm-project log -1 --format=%h"
      RESULT_VARIABLE clang_version_status
@@ -203,19 +68,16 @@ function (config_with_llvm)
     third_party/perf_data_converter/src/quipper/perf_data.proto
     third_party/perf_data_converter/src/quipper/perf_parser_options.proto
     third_party/perf_data_converter/src/quipper/perf_stat.proto)
-  protobuf_generate(
-    TARGET perf_proto
-    LANGUAGE cpp)
+  protobuf_generate(TARGET perf_proto LANGUAGE cpp)
   target_link_libraries(perf_proto PUBLIC protobuf::libprotobuf)
 
   add_library(llvm_propeller_cfg_proto llvm_propeller_cfg.proto)
-  protobuf_generate(
-    TARGET llvm_propeller_cfg_proto
-    LANGUAGE cpp)
+  protobuf_generate(TARGET llvm_propeller_cfg_proto LANGUAGE cpp)
   target_link_libraries(llvm_propeller_cfg_proto PUBLIC protobuf::libprotobuf)
   
   add_library(llvm_propeller_options_proto llvm_propeller_options.proto)
-  target_link_libraries(llvm_propeller_options_proto PUBLIC protobuf::libprotobuf)
+  target_link_libraries(llvm_propeller_options_proto PUBLIC
+    protobuf::libprotobuf)
   protobuf_generate(
     TARGET llvm_propeller_options_proto
     LANGUAGE cpp)
@@ -246,7 +108,7 @@ function (config_with_llvm)
   add_library(perfdata_reader OBJECT perfdata_reader.cc)
   target_include_directories(perfdata_reader
     PUBLIC ${PROJECT_BINARY_DIR}/third_party/perf_data_converter/src/quipper)
-  target_link_libraries(perfdata_reader PUBLIC protobuf::libprotobuf perf_proto)
+  target_link_libraries(perfdata_reader PUBLIC perf_proto)
 
   add_library(symbol_map OBJECT
     source_info.cc
@@ -269,7 +131,6 @@ function (config_with_llvm)
     profile_writer.cc)
   add_dependencies(llvm_profile_writer quipper_perf)
   target_include_directories(llvm_profile_writer PUBLIC
-    libprotobuf
     third_party/perf_data_converter/src
     third_party/perf_data_converter/src/quipper
     util/regexp
@@ -392,7 +253,6 @@ function (config_with_llvm)
 
   add_executable(llvm_profile_writer_test llvm_profile_writer_test.cc)
   target_include_directories(llvm_profile_writer_test PUBLIC
-    libprotobuf
     third_party/perf_data_converter/src
     third_party/perf_data_converter/src/quipper
     util/regexp)
@@ -804,9 +664,5 @@ function (config_with_llvm)
     DEPENDS prepare_cmds)
 endfunction()
 
-if (DEFINED WITH_LLVM)
-  config_with_llvm()
-else ()
-  config_without_llvm()
-endif ()
+config_with_llvm()
 enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,7 @@ function (config_with_llvm)
     third_party/perf_data_converter/src
     third_party/perf_data_converter/src/quipper
     util/regexp
+    ${PROTOBUF_INCLUDE_DIR}
     ${PROJECT_BINARY_DIR}/third_party/perf_data_converter/src/quipper)
   target_link_libraries(llvm_profile_writer
     absl::flat_hash_map
@@ -285,6 +286,8 @@ function (config_with_llvm)
     llvm_propeller_cfg_testutil.cc
     llvm_propeller_function_cluster_info_matchers.cc
     llvm_propeller_mock_program_cfg_builder.cc)
+  target_include_directories(llvm_propeller_test_objects
+    PUBLIC ${PROTOBUF_INCLUDE_DIR})
 
   add_library(llvm_propeller_objects OBJECT
     addr2cu.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,22 +198,29 @@ function (config_with_llvm)
     util/regexp)
 
   find_package(Protobuf REQUIRED)
-  protobuf_generate_cpp(PERF_DATA_PROTO_CC PERF_DATA_PROTO_HDR third_party/perf_data_converter/src/quipper/perf_data.proto)
-  protobuf_generate_cpp(PERF_PARSER_OPTIONS_CC PERF_PARSER_OPTIONS_HDR third_party/perf_data_converter/src/quipper/perf_parser_options.proto)
-  protobuf_generate_cpp(PERF_STAT_CC PERF_STAT_HDR third_party/perf_data_converter/src/quipper/perf_stat.proto)
-  add_library(perf_data_proto OBJECT ${PERF_DATA_PROTO_CC})
-  add_library(perf_parser_options_proto OBJECT ${PERF_PARSER_OPTIONS_CC})
-  add_library(perf_stat_proto OBJECT ${PERF_STAT_CC})
 
-  protobuf_generate_cpp(LLVM_PROPELLER_CFG_PROTO_CC LLVM_PROPELLER_CFG_PROTO_HDR llvm_propeller_cfg.proto)
-  add_library(llvm_propeller_cfg_proto OBJECT ${LLVM_PROPELLER_CFG_PROTO_CC})
+  add_library(perf_proto
+    third_party/perf_data_converter/src/quipper/perf_data.proto
+    third_party/perf_data_converter/src/quipper/perf_parser_options.proto
+    third_party/perf_data_converter/src/quipper/perf_stat.proto)
+  protobuf_generate(
+    TARGET perf_proto
+    LANGUAGE cpp)
+  target_link_libraries(perf_proto PUBLIC protobuf::libprotobuf)
 
-  protobuf_generate_cpp(LLVM_PROPELLER_OPTIONS_PROTO_CC LLVM_PROPELLER_OPTIONS_PROTO_HDR llvm_propeller_options.proto)
-  add_library(llvm_propeller_options OBJECT llvm_propeller_options_builder.cc ${LLVM_PROPELLER_OPTIONS_PROTO_CC})
-  add_dependencies(llvm_propeller_options quipper_perf)
-
-  add_library(create_llvm_prof_object OBJECT create_llvm_prof.cc)
-  add_dependencies(create_llvm_prof_object llvm_propeller_options LLVMDebugInfoDWARF)
+  add_library(llvm_propeller_cfg_proto llvm_propeller_cfg.proto)
+  protobuf_generate(
+    TARGET llvm_propeller_cfg_proto
+    LANGUAGE cpp)
+  target_link_libraries(llvm_propeller_cfg_proto PUBLIC protobuf::libprotobuf)
+  
+  add_library(llvm_propeller_options_proto llvm_propeller_options.proto)
+  target_link_libraries(llvm_propeller_options_proto PUBLIC protobuf::libprotobuf)
+  protobuf_generate(
+    TARGET llvm_propeller_options_proto
+    LANGUAGE cpp)
+  add_library(llvm_propeller_options STATIC llvm_propeller_options_builder.cc)
+  target_link_libraries(llvm_propeller_options quipper_perf llvm_propeller_options_proto)
 
   add_library(mini_disassembler OBJECT mini_disassembler.cc)
   target_link_libraries(mini_disassembler
@@ -233,14 +240,13 @@ function (config_with_llvm)
 
   add_library(sample_reader OBJECT sample_reader.cc spe_sample_reader.cc)
   target_include_directories(sample_reader PUBLIC util)
-  target_link_libraries(sample_reader absl::base quipper_perf LLVMObject)
-  add_dependencies(sample_reader perf_data_proto)
+  target_link_libraries(sample_reader absl::base quipper_perf perf_proto LLVMObject)
   add_dependencies(sample_reader llvm_propeller_objects)
 
   add_library(perfdata_reader OBJECT perfdata_reader.cc)
-  add_dependencies(perfdata_reader perf_data_proto)
-  add_dependencies(perfdata_reader perf_parser_options_proto)
-  add_dependencies(perfdata_reader perf_stat_proto)
+  target_include_directories(perfdata_reader
+    PUBLIC ${PROJECT_BINARY_DIR}/third_party/perf_data_converter/src/quipper)
+  target_link_libraries(perfdata_reader PUBLIC protobuf::libprotobuf perf_proto)
 
   add_library(symbol_map OBJECT
     source_info.cc
@@ -266,7 +272,8 @@ function (config_with_llvm)
     libprotobuf
     third_party/perf_data_converter/src
     third_party/perf_data_converter/src/quipper
-    util/regexp)
+    util/regexp
+    ${PROJECT_BINARY_DIR}/third_party/perf_data_converter/src/quipper)
   target_link_libraries(llvm_profile_writer
     absl::flat_hash_map
     absl::node_hash_set
@@ -336,7 +343,7 @@ function (config_with_llvm)
     LLVMDebugInfoDWARF
     LLVMSupport)
 
-  add_executable(create_llvm_prof)
+  add_executable(create_llvm_prof create_llvm_prof.cc)
   target_link_libraries(create_llvm_prof 
     absl::base
     absl::check
@@ -346,7 +353,6 @@ function (config_with_llvm)
     absl::statusor
     absl::str_format
     absl::strings
-    create_llvm_prof_object
     glog
     llvm_profile_reader
     llvm_profile_writer
@@ -436,7 +442,6 @@ function (config_with_llvm)
     llvm_propeller_node_chain.cc
     llvm_propeller_node_chain_assembly.cc
     llvm_propeller_node_chain_builder.cc
-    llvm_propeller_options_builder.cc
     llvm_propeller_perf_branch_frequencies_aggregator.cc
     llvm_propeller_perf_lbr_aggregator.cc
     llvm_propeller_profile_computer.cc
@@ -447,11 +452,14 @@ function (config_with_llvm)
     llvm_propeller_program_cfg_proto_builder.cc
     llvm_propeller_statistics.cc
     llvm_propeller_telemetry_reporter.cc
-    spe_tid_pid_provider.cc
-    ${LLVM_PROPELLER_CFG_PROTO_CC}
-    ${LLVM_PROPELLER_OPTIONS_PROTO_CC})
-  add_dependencies(llvm_propeller_objects absl::statusor llvm_profile_writer status_provider)
-  target_link_libraries(llvm_propeller_objects LLVMDebugInfoDWARF)
+    spe_tid_pid_provider.cc)
+  target_link_libraries(llvm_propeller_objects
+    absl::statusor
+    llvm_profile_writer
+    llvm_propeller_options
+    llvm_propeller_cfg_proto
+    status_provider
+    LLVMDebugInfoDWARF)
 
   add_executable(instruction_map_test addr2line.cc instruction_map.cc instruction_map_test.cc)
   target_link_libraries(instruction_map_test
@@ -777,20 +785,17 @@ function (config_with_llvm)
     third_party/perf_data_converter/src/quipper/perf_reader.cc
     third_party/perf_data_converter/src/quipper/perf_parser.cc
     third_party/perf_data_converter/src/quipper/sample_info_reader.cc
-    third_party/perf_data_converter/src/quipper/string_utils.cc
-    ${PERF_DATA_PROTO_HDR}
-    ${PERF_DATA_PROTO_CC}
-    ${PERF_PARSER_OPTIONS_HDR}
-    ${PERF_PARSER_OPTIONS_CC}
-    ${PERF_STAT_CC}
-    ${PERF_STAT_HDR})
+    third_party/perf_data_converter/src/quipper/string_utils.cc)
+
   target_include_directories(quipper_perf PRIVATE
     third_party/abseil)
   target_include_directories(quipper_perf BEFORE
     PUBLIC
     third_party/perf_data_converter/src
-    third_party/perf_data_converter/src/quipper)
-  target_link_libraries(quipper_perf ${Protobuf_LIBRARIES} ${LIBELF_LIBRARIES} ${LIBCRYPTO_LIBRARIES})
+    third_party/perf_data_converter/src/quipper
+    ${PROJECT_BINARY_DIR}/third_party/perf_data_converter/src/quipper)
+  target_link_libraries(quipper_perf
+    perf_proto ${LIBELF_LIBRARIES} ${LIBCRYPTO_LIBRARIES})
 
   add_custom_command(PRE_BUILD
     OUTPUT prepare_cmds

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@
     $ mkdir build
     $ cd build 
 	$ # To build LLVM Propeller support
-    $ cmake -DWITH_LLVM=On -DCMAKE_C_COMPILER=clang-10 -DCMAKE_CXX_COMPILER=clang++-10 -DCMAKE_BUILD_TYPE=Release ../
+    $ cmake -DENABLE_TOOL=LLVM -DCMAKE_C_COMPILER=clang-10 -DCMAKE_CXX_COMPILER=clang++-10 -DCMAKE_BUILD_TYPE=Release ../
 	$ # Or to build tools for GCC
-	$ cmake -DCMAKE_C_COMPILER=clang-10 -DCMAKE_CXX_COMPILER=clang++-10 -DCMAKE_BUILD_TYPE=Release ../
+	$ cmake -DENABLE_TOOL=GCOV -DCMAKE_C_COMPILER=clang-10 -DCMAKE_CXX_COMPILER=clang++-10 -DCMAKE_BUILD_TYPE=Release ../
     $ make -j 4
 ```
 To build with g++-9 installed from the package repository use `-DCMAKE_C_COMPILER=gcc-9 -DCMAKE_CXX_COMPILER=g++9` instead in the cmake command above.

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@
     $ mkdir build
     $ cd build 
     $ # Build LLVM tools for AUtoFDO and Propeller
-    $ cmake -DENABLE_TOOL=LLVM -DCMAKE_C_COMPILER=clang-10 -DCMAKE_CXX_COMPILER=clang++-10 -DCMAKE_BUILD_TYPE=Release ../
+    $ cmake -DENABLE_TOOL=LLVM -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release ../
     $ # Build autofdo tools
-    $ cmake -DENABLE_TOOL=GCOV -DCMAKE_C_COMPILER=clang-10 -DCMAKE_CXX_COMPILER=clang++-10 -DCMAKE_BUILD_TYPE=Release ../
+    $ cmake -DENABLE_TOOL=GCOV -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release ../
     $ make -j 4
 ```
 
-To build with g++-9 installed from the package repository use `-DCMAKE_C_COMPILER=gcc-9 -DCMAKE_CXX_COMPILER=g++9` instead in the cmake command above.
+To build with g++-9 installed from the package repository use `-DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++` instead in the cmake command above.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@
     $ cd autofdo
     $ mkdir build
     $ cd build 
-    $ cmake -DCMAKE_C_COMPILER=clang-10 -DCMAKE_CXX_COMPILER=clang++-10 -DCMAKE_BUILD_TYPE=Release ../
+	$ # To build LLVM Propeller support
+    $ cmake -DWITH_LLVM=On -DCMAKE_C_COMPILER=clang-10 -DCMAKE_CXX_COMPILER=clang++-10 -DCMAKE_BUILD_TYPE=Release ../
+	$ # Or to build tools for GCC
+	$ cmake -DCMAKE_C_COMPILER=clang-10 -DCMAKE_CXX_COMPILER=clang++-10 -DCMAKE_BUILD_TYPE=Release ../
     $ make -j 4
 ```
 To build with g++-9 installed from the package repository use `-DCMAKE_C_COMPILER=gcc-9 -DCMAKE_CXX_COMPILER=g++9` instead in the cmake command above.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,20 @@
 
-# 1. Install prerequisites on Ubuntu 20.04
+# 1. Install prerequisites on Ubuntu 20.04 and 22.04
 
 ```
-    $ sudo apt install libunwind-dev libgflags-dev libssl-dev libelf-dev protobuf-compiler cmake zstd clang g++
+    $ sudo apt install libunwind-dev libgflags-dev libssl-dev libelf-dev protobuf-compiler cmake libzstd-dev clang g++
 ```
 
-## 2 Build autofdo tools using clang-10
+## 1.1 For Ubuntu 20.04 users, the cmake version (3.16.3) is too old to build third_party/llvm, you can upgrade your cmake by following steps in https://askubuntu.com/questions/355565/how-do-i-install-the-latest-version-of-cmake-from-the-command-line
+
+```
+    $ sudo apt purge --auto-remove cmake
+    $ wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
+    $ sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ focal main'     
+    $ sudo apt update && sudo apt install cmake
+```
+
+## 2 Build autofdo tools
 
 ```
     $ git clone --recursive --depth 1 https://github.com/google/autofdo.git
@@ -13,10 +22,11 @@
     $ cd autofdo
     $ mkdir build
     $ cd build 
-	$ # To build LLVM Propeller support
+    $ # Build LLVM tools for AUtoFDO and Propeller
     $ cmake -DENABLE_TOOL=LLVM -DCMAKE_C_COMPILER=clang-10 -DCMAKE_CXX_COMPILER=clang++-10 -DCMAKE_BUILD_TYPE=Release ../
-	$ # Or to build tools for GCC
-	$ cmake -DENABLE_TOOL=GCOV -DCMAKE_C_COMPILER=clang-10 -DCMAKE_CXX_COMPILER=clang++-10 -DCMAKE_BUILD_TYPE=Release ../
+    $ # Build autofdo tools
+    $ cmake -DENABLE_TOOL=GCOV -DCMAKE_C_COMPILER=clang-10 -DCMAKE_CXX_COMPILER=clang++-10 -DCMAKE_BUILD_TYPE=Release ../
     $ make -j 4
 ```
+
 To build with g++-9 installed from the package repository use `-DCMAKE_C_COMPILER=gcc-9 -DCMAKE_CXX_COMPILER=g++9` instead in the cmake command above.


### PR DESCRIPTION
Now we have LLVM source as a submodule, we can always build with LLVM source, so removed the case when WITH_LLVM=Off.

Also replaced "protobuf_generate_cpp" with a more modern "protobuf_generate". On my system that is not Ubuntu , protobuf_generate_cpp throws error. 

Reference: [[1]](https://gitlab.kitware.com/cmake/cmake/-/issues/21228) [[2]](https://stackoverflow.com/questions/52533396/cmake-cant-find-protobuf-protobuf-generate-cpp/64037117#64037117)