### PR TITLE
Avoid breakages for WITH_LLVM builds with libprotobuf < 3.19.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # 1. Install prerequisites on Ubuntu 20.04
 
 ```
-    $ sudo apt install libunwind-dev libgflags-dev libssl-dev libelf-dev protobuf-compiler cmake clang g++
+    $ sudo apt install libunwind-dev libgflags-dev libssl-dev libelf-dev protobuf-compiler cmake zstd clang g++
 ```
 
 ## 2 Build autofdo tools using clang-10

--- a/spe_tid_pid_provider.cc
+++ b/spe_tid_pid_provider.cc
@@ -14,7 +14,7 @@
 #include "third_party/abseil/absl/strings/str_cat.h"
 #include "quipper/arm_spe_decoder.h"
 #include "quipper/perf_data_utils.h"
-#include "google/protobuf/repeated_ptr_field.h"
+#include "google/protobuf/repeated_field.h"
 
 namespace devtools_crosstool_autofdo {
 

--- a/spe_tid_pid_provider.h
+++ b/spe_tid_pid_provider.h
@@ -11,7 +11,7 @@
 #include "third_party/abseil/absl/container/flat_hash_map.h"
 #include "third_party/abseil/absl/status/statusor.h"
 #include "quipper/arm_spe_decoder.h"
-#include "google/protobuf/repeated_ptr_field.h"
+#include "google/protobuf/repeated_field.h"
 
 namespace devtools_crosstool_autofdo {
 


### PR DESCRIPTION
Recent commit 623c777 introduced spe_tid_pid_provider, which includes
`repeated_ptr_field.h` (`RepeatedPtrField` was only moved to its own
header in 3.19.0).

`repeated_field.h` transitively includes `repeated_ptr_field` in new
versions of libprotobuf for backwards compatibility reasons, so we can
include that instead.