### PR TITLE
Fixed testcase failures when build directory is not under the source directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -794,7 +794,7 @@ function (config_with_llvm)
 
   add_custom_command(PRE_BUILD
     OUTPUT prepare_cmds
-    COMMAND ln -s -f ../testdata testdata)
+    COMMAND ln -s -f ${CMAKE_HOME_DIRECTORY}/testdata)
   add_custom_target(prepare ALL
     DEPENDS prepare_cmds)
 endfunction()


### PR DESCRIPTION
"../testdata" assumes the build directory is inside the source directory, which is not always true.  Fixed this by using the source directory explicitly.