### PR TITLE
Fix compilation error when building using github build bot.

### DIFF
--- a/llvm_propeller_cfg_test.cc
+++ b/llvm_propeller_cfg_test.cc
@@ -177,7 +177,8 @@ TEST(LlvmPropellerCfg, CloneCfg) {
                IsCfgEdge(NodeIntraIdIs(CFGNode::IntraCfgId{3, 0}),
                          NodeIntraIdIs(CFGNode::IntraCfgId{1, 0}), 100,
                          CFGEdge::Kind::kBranchOrFallthough)}),
-          CfgInterEdgesMatcher(absl::Span<const testing::Matcher<CFGEdge>>{}))));
+          CfgInterEdgesMatcher(
+              absl::Span<const testing::Matcher<CFGEdge>>{}))));
 }
 
 TEST(LlvmPropellerCfg, GetNodeFrequencyStats) {

--- a/llvm_propeller_cfg_test.cc
+++ b/llvm_propeller_cfg_test.cc
@@ -8,6 +8,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "third_party/abseil/absl/container/flat_hash_map.h"
+#include "third_party/abseil/absl/types/span.h"
 
 namespace devtools_crosstool_autofdo {
 namespace {
@@ -176,7 +177,7 @@ TEST(LlvmPropellerCfg, CloneCfg) {
                IsCfgEdge(NodeIntraIdIs(CFGNode::IntraCfgId{3, 0}),
                          NodeIntraIdIs(CFGNode::IntraCfgId{1, 0}), 100,
                          CFGEdge::Kind::kBranchOrFallthough)}),
-          CfgInterEdgesMatcher({}))));
+          CfgInterEdgesMatcher(absl::Span<const testing::Matcher<CFGEdge>>{}))));
 }
 
 TEST(LlvmPropellerCfg, GetNodeFrequencyStats) {


### PR DESCRIPTION
GCC used in the bot is Ubuntu 22.04 - gcc 11.4.0, the error was (buildbot log: https://github.com/google/autofdo/actions/runs/9962415417/job/27526112613)

Tested:
  buildbot build passed
  clang / (newer) gcc build passed on my workstation

/home/runner/work/autofdo/autofdo/llvm_propeller_cfg_test.cc: In member function ‘virtual void devtools_crosstool_autofdo::{anonymous}::LlvmPropellerCfg_CloneCfg_Test::TestBody()’: /home/runner/work/autofdo/autofdo/llvm_propeller_cfg_test.cc:179:34: error: call of overloaded ‘CfgInterEdgesMatcher(<brace-enclosed initializer list>)’ is ambiguous
  179 |           CfgInterEdgesMatcher({}))));
      |                                  ^
In file included from /home/runner/work/autofdo/autofdo/llvm_propeller_cfg_test.cc:6:
/home/runner/work/autofdo/autofdo/llvm_propeller_cfg_matchers.h:154:12: note: candidate: ‘devtools_crosstool_autofdo::CfgInterEdgesMatcher::CfgInterEdgesMatcher(absl::lts_20240116::Span<const testing::Matcher<devtools_crosstool_autofdo::CFGEdge> >)’
  154 |   explicit CfgInterEdgesMatcher(
      |            ^~~~~~~~~~~~~~~~~~~~
/home/runner/work/autofdo/autofdo/llvm_propeller_cfg_matchers.h:148:7: note: candidate: ‘devtools_crosstool_autofdo::CfgInterEdgesMatcher::CfgInterEdgesMatcher(const devtools_crosstool_autofdo::CfgInterEdgesMatcher&)’
  148 | class CfgInterEdgesMatcher {
      |       ^~~~~~~~~~~~~~~~~~~~
/home/runner/work/autofdo/autofdo/llvm_propeller_cfg_matchers.h:148:7: note: candidate: ‘devtools_crosstool_autofdo::CfgInterEdgesMatcher::CfgInterEdgesMatcher(devtools_crosstool_autofdo::CfgInterEdgesMatcher&&)’
[ 64%] Building CXX object third_party/llvm-project/llvm/lib/Analysis/CMakeFiles/LLVMAnalysis.dir/RegionPass.cpp.o
make[2]: Leaving directory '/home/runner/work/autofdo/autofdo/build'
make[2]: *** [CMakeFiles/llvm_propeller_cfg_test.dir/build.make:76: CMakeFiles/llvm_propeller_cfg_test.dir/llvm_propeller_cfg_test.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:6254: CMakeFiles/llvm_propeller_cfg_test.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....