### PR TITLE
Add a config to build and run on PRs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: autofdo CI
+
+on:
+  push:
+    branches: [ $default-branch ]
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+  # Manual trigger using the Actions page.
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+
+    runs-on: ubuntu-22.04-8core
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: 'recursive'
+    - name: install dependencies
+      run: sudo apt-get -y install libunwind-dev libgflags-dev libssl-dev libelf-dev protobuf-compiler libzstd-dev
+
+    - name: cmake for llvm
+      run: cmake -DENABLE_TOOL=LLVM -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -B build-llvm
+    - name: build for llvm
+      run: make -j 8 -C build-llvm
+    - name: run tests for llvm
+      run: make test -C build-llvm
+
+    - name: cmake for gcov
+      run: cmake -DENABLE_TOOL=GCOV -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -B build-gcov
+    - name: build for gcov
+      run: make -j 8 -C build-gcov
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,11 +134,11 @@ function (build_gcov)
 endfunction()
 
 function (build_llvm)
-  execute_process(COMMAND sh -c "git -C ${CMAKE_HOME_DIRECTORY}/third_party/llvm-project log -1 --format=%h"
+  execute_process(COMMAND sh -c "git -C ${CMAKE_HOME_DIRECTORY}/third_party/llvm-project log -1 --format=%H"
      RESULT_VARIABLE clang_version_status
      OUTPUT_VARIABLE CLANG_VERSION_OUTPUT)
 
-  set(CLANG_KNOWN_GIT_COMMIT_HASH "e4f9175d2395")
+  set(CLANG_KNOWN_GIT_COMMIT_HASH "e4f9175d23950ecaef32db075ed47dafe3be555c")
   if (clang_version_status)
      message(WARNING "Could not get clang commit hash : Use clang git hash " ${CLANG_KNOWN_GIT_COMMIT_HASH})
   else()


### PR DESCRIPTION
Currently the CI config targets 22.04 with tests being run for the LLVM tools built with clang. We also build GCOV tools built with GCC but do not test them yet since a couple of tests are failing.

Also fix the commit hash check.