### PR TITLE
Added missing support for "--propeller_output_module_names"

### DIFF
--- a/create_llvm_prof.cc
+++ b/create_llvm_prof.cc
@@ -113,6 +113,14 @@ ABSL_FLAG(bool, propeller_layout_only, false,
           "hot ones. Default to \"false\". Mutually exclusive with "
           "--propeller_split_only. Only valid when --format=propeller.");
 
+ABSL_FLAG(bool, propeller_output_module_name, false,
+          "Embed module names in the function cluster information. This "
+          "requires debug info - the binary has to be built with \"-g\" or "
+          "\"-g -gsplit-dwarf\", in the latter case, a dwp file whose name "
+          "equals to the original binary filename with a \".dwp\" suffix is "
+          "required to exist alongside with the original binary, an error will "
+          "be reported if such file is not found.");
+
 ABSL_FLAG(int32_t, propeller_cluster_encoding_version,
           static_cast<int32_t>(
               devtools_crosstool_autofdo::ClusterEncodingVersion::LATEST),
@@ -177,6 +185,8 @@ devtools_crosstool_autofdo::PropellerOptions CreatePropellerOptionsFromFlags() {
           .SetCodeLayoutParamsInterFunctionReordering(
               absl::GetFlag(FLAGS_propeller_inter_function_ordering))
           .SetHttp(absl::GetFlag(FLAGS_http))
+          .SetOutputModuleName(
+              absl::GetFlag(FLAGS_propeller_output_module_name))
           .SetVerboseClusterOutput(
               absl::GetFlag(FLAGS_propeller_verbose_cluster_output)));
 }


### PR DESCRIPTION
 The last sync seems dropped --propeller_output_module_name, which is critical to binaries that cannot be built with -funique-internal-linkage-names.
