### PR TITLE
RELEASE notes for v0.30.1

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,9 +1,9 @@
-Release Notes for v0.31
+Release Notes for v0.30.1
 
 ## What's Changed
 * Added missing support for "--propeller_output_module_names" by @shenhanc78 in https://github.com/google/autofdo/pull/219
-* Added --propeller_cluster_encoding_version which was missing from the previous release by @shenhanc78 in https://github.com/google/autofdo/pull/220
+* The last sync seems dropped --propeller_cluster_encoding_version by @shenhanc78 in https://github.com/google/autofdo/pull/220
 * Make --propeller_chain_split defaults to true. by @shenhanc78 in https://github.com/google/autofdo/pull/221
 
 
-**Full Changelog**: https://github.com/google/autofdo/compare/v0.30...v0.31
+**Full Changelog**: https://github.com/google/autofdo/compare/v0.30...v0.30.1

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,14 +1,9 @@
-Release Notes for v0.30
+Release Notes for v0.31
 
 ## What's Changed
-* Avoid breakages for WITH_LLVM builds with libprotobuf < 3.19.0 by @dhoekwater in https://github.com/google/autofdo/pull/200
-* Fixed testcase failures when build directory is not under the source directory by @shenhanc78 in https://github.com/google/autofdo/pull/206
-* Fix compilation error when building using github build bot. by @shenhanc78 in https://github.com/google/autofdo/pull/210
-* Removed WITH_LLVM and replaced protobuf_generate_cpp with more modern protobuf_generate by @shenhanc78 in https://github.com/google/autofdo/pull/199
-* Fix format/indention error in README. by @shenhanc78 in https://github.com/google/autofdo/pull/212
-* Add a config to build and run on PRs. by @snehasish in https://github.com/google/autofdo/pull/213
-* Update README.md by @snehasish in https://github.com/google/autofdo/pull/214
-* Add a workflow to create release build. by @shenhanc78 in https://github.com/google/autofdo/pull/217
-* Build full-static LLVM tools binaries by @shenhanc78 in https://github.com/google/autofdo/pull/216
+* Added missing support for "--propeller_output_module_names" by @shenhanc78 in https://github.com/google/autofdo/pull/219
+* Added --propeller_cluster_encoding_version which was missing from the previous release by @shenhanc78 in https://github.com/google/autofdo/pull/220
+* Make --propeller_chain_split defaults to true. by @shenhanc78 in https://github.com/google/autofdo/pull/221
 
-**Full Changelog**: https://github.com/google/autofdo/compare/v0.20.1...v0.30
+
+**Full Changelog**: https://github.com/google/autofdo/compare/v0.30...v0.31


### PR DESCRIPTION
Release Notes for v0.30.1

## What's Changed
* Added missing support for "--propeller_output_module_names" by @shenhanc78 in https://github.com/google/autofdo/pull/219
* The last sync seems dropped --propeller_cluster_encoding_version by @shenhanc78 in https://github.com/google/autofdo/pull/220
* Make --propeller_chain_split defaults to true. by @shenhanc78 in https://github.com/google/autofdo/pull/221


**Full Changelog**: https://github.com/google/autofdo/compare/v0.30...v0.30.1


