### PR TITLE
Update ci.yml to run tests with gcov build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,6 @@ jobs:
       run: cmake -DENABLE_TOOL=GCOV -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -B build-gcov
     - name: build for gcov
       run: make -j 8 -C build-gcov
+    - name: run tests for gcov
+      run: make test -C build-gcov
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,10 @@ function (build_gcov)
   add_subdirectory(third_party/abseil)
   add_subdirectory(third_party/glog)
 
+  add_custom_target(exclude_extlib_tests ALL
+    COMMAND rm -f ${glog_BINARY_DIR}/CTestTestfile.cmake
+    COMMAND rm -f ${absl_BINARY_DIR}/CTestTestfile.cmake)
+
   include_directories(${CMAKE_HOME_DIRECTORY}
     third_party/glog/src
     third_party/abseil


### PR DESCRIPTION
Disable third party tests in build-gcov similar to what is done in build-llvm.

Currently no tests will run for build-gcov, this is in preparation for adding some tests.