### PR TITLE
Added support for building on CentOS 9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,14 @@ set(CMAKE_CXX_STANDARD 17)
 set(ABSL_PROPAGATE_CXX_STD on)
 
 project(autofdo)
-set (Protobuf_USE_STATIC_LIBS TRUE)
+
+if (NOT DEFINED BUILD_SHARED)
+  set(BUILD_SHARED FALSE)
+endif()
+
+if (NOT ${BUILD_SHARED})
+  set (Protobuf_USE_STATIC_LIBS TRUE)
+endif()
 
 function (execute_perf_protobuf)
 
@@ -201,7 +208,9 @@ function (build_llvm)
   set (LLVM_TARGETS_TO_BUILD X86 AArch64 CACHE STRING
     "Semicolon-separated list of LLVM targets to build, or \"all\".")
   set (LLVM_ENABLE_ZSTD FORCE_ON)
-  set (LLVM_USE_STATIC_ZSTD TRUE CACHE BOOL "use static zstd")
+  if (NOT ${BUILD_SHARED})
+    set (LLVM_USE_STATIC_ZSTD TRUE CACHE BOOL "use static zstd")
+  endif()
   # terminfo is not needed by create_llvm_prof
   set (LLVM_ENABLE_TERMINFO OFF CACHE BOOL "enable terminfo")
   ###
@@ -452,6 +461,8 @@ function (build_llvm)
     llvm_propeller_mock_program_cfg_builder.cc)
   target_include_directories(llvm_propeller_test_objects
     PUBLIC ${PROTOBUF_INCLUDE_DIR})
+  target_link_libraries(llvm_propeller_test_objects
+    llvm_propeller_cfg_proto)
 
   add_library(llvm_propeller_objects OBJECT
     addr2cu.cc
@@ -845,11 +856,13 @@ if (${enable_tool} STREQUAL gcov)
 elseif (${enable_tool} STREQUAL llvm)
   message(STATUS "Building tool \"LLVM\" ...")
 
-  # Build static binaries.
-  set (BUILD_SHARED_LIBS OFF)
-  set (CMAKE_FIND_LIBRARY_SUFFIXES ".a")
-  # Link static executables.
-  set (CMAKE_EXE_LINKER_FLAGS "-static")
+  if (NOT ${BUILD_SHARED})
+    # Build static binaries.
+    set (BUILD_SHARED_LIBS OFF)
+    set (CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+    # Link static executables.
+    set (CMAKE_EXE_LINKER_FLAGS "-static")
+  endif()
 
   build_llvm()
 else ()

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
+AutoFDO tools can be built on Ubuntu 20.04, 22.04 or CentOS 9, choose 1a or 1b to install prerequisites.
 
-# 1. Install prerequisites on Ubuntu 20.04 and 22.04
+# 1a. Install prerequisites on Ubuntu 20.04 and 22.04
 
 ```
     $ sudo apt install libunwind-dev libgflags-dev libssl-dev libelf-dev protobuf-compiler cmake libzstd-dev clang g++
@@ -16,17 +17,28 @@ The cmake version (3.16.3) on Ubuntu 20.04 LTS is too old to build third_party/l
     $ sudo apt update && sudo apt install cmake
 ```
 
+# 1b. Install prerequisites on CentOS 9
+
+```
+    dnf config-manager --set-enabled crb
+    dnf install epel-release epel-next-release
+    dnf install git cmake ninja-build elfutils-libelf libunwind-devel clang clang-devel clang-libs protobuf-devel protobuf-compiler elfutils-libelf-devel gcc gcc-c++ openssl-devel
+```
+
+
 ## 2 Build autofdo tools
+
+Note, "-DBUILD_SHARED=On" is required for CentOS 9, this will build the tools linked with shared libraries. For Ubuntu 20.04 and Ubuntu 22.04, "-DBUILD_SHARED" is optional, when it is not given, this will build the tools linked statically.
 
 ```
     $ git clone --recursive --depth 1 https://github.com/google/autofdo.git
     $ cd autofdo
     $ mkdir build
-    $ cd build 
-    $ # Build LLVM tools for AUtoFDO and Propeller
-    $ cmake -DENABLE_TOOL=LLVM -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release ../
+    $ cd build
+    $ # Build LLVM tools for AutoFDO and Propeller
+    $ cmake -DENABLE_TOOL=LLVM -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED=On ../
     $ # Build autofdo tools
-    $ cmake -DENABLE_TOOL=GCOV -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release ../
+    $ cmake -DENABLE_TOOL=GCOV -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED=On ../
     $ make -j 4
 ```
 


### PR DESCRIPTION
#228 reported build failure on centos.

Added -DBUILD_SHARED=On/Off to control whether to build static linked or dynamic linked binaries.

CentOS 9 (Fedora) does not contain in its repositories some of the required static libraries. -DBUILD_SHARED=On is required to build on CentOS 9.

Also added notes on how to install prerequisites and build on CentOS 9.
