### PR TITLE
Update runners to ubuntu-24.04 from deprecated ubuntu-20.04 label

### DIFF
--- a/.github/workflows/create-release-build.yaml
+++ b/.github/workflows/create-release-build.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build_release:
-    runs-on: ubuntu-22.04-8core
+    runs-on: 'ubuntu-24.04-8core'
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This is a http://go/LSC run by http://go/ghss to upgrade all self-hosted ubuntu-22.04 runners to ubuntu-24.04.

This is a courtesy PR to help you upgrade to the latest release of ubuntu runners, it is not mandatory at this time.

WARNING: We do not know if the updated label is compatiable with your workflow or not.

If you do not want to merge this PR, feel free to close it.

More context and feedback: http://b/406537467
