### PR TITLE
Fix errors found through valgrind/asan

### DIFF
--- a/spe_sample_reader.cc
+++ b/spe_sample_reader.cc
@@ -162,6 +162,7 @@ absl::StatusOr<PerfDataReader> PerfSpeDataSampleReader::CreatePerfDataReader(
   ASSIGN_OR_RETURN(PerfDataProvider::BufferHandle perf_data,
                    FetchPerfData(profile_file));
 
+  std::set<std::string> filenames;
   std::vector<absl::string_view> match_mmap_names;
   // Only use the mmap name regex if there is no build_id.
   if (binary_content.build_id.empty()) {
@@ -174,7 +175,6 @@ absl::StatusOr<PerfDataReader> PerfSpeDataSampleReader::CreatePerfDataReader(
 
     reader.ReadFromPointer(perf_data.buffer->getBufferStart(),
                            perf_data.buffer->getBufferSize());
-    std::set<std::string> filenames;
     reader.GetFilenamesAsSet(&filenames);
     // Filter out filenames that don't match the regex.
     absl::c_copy_if(filenames, std::back_inserter(match_mmap_names),

--- a/util/symbolize/elf_reader.cc
+++ b/util/symbolize/elf_reader.cc
@@ -657,32 +657,32 @@ class ElfReaderImpl {
   friend class SymbolIterator<ElfArch>;
 
   // The file we're reading.
-  const string path_;
+  const string path_ {};
   // Open file descriptor for path_. Not owned by this object.
-  const int fd_;
+  const int fd_ {};
 
   // The global header of the ELF file.
-  typename ElfArch::Ehdr header_;
+  typename ElfArch::Ehdr header_ {};
 
   // The header of the first section. This may be used to supplement the ELF
   // file header.
-  typename ElfArch::Shdr first_section_header_;
+  typename ElfArch::Shdr first_section_header_ {};
 
   // Array of GetNumSections() section headers, allocated when we read
   // in the global header.
-  typename ElfArch::Shdr *section_headers_;
+  typename ElfArch::Shdr *section_headers_ {};
 
   // Array of GetNumProgramHeaders() program headers, allocated when we read
   // in the global header.
-  typename ElfArch::Phdr *program_headers_;
+  typename ElfArch::Phdr *program_headers_ {};
 
   // An array of pointers to ElfSectionReaders. Sections are
   // mmaped as they're needed and not released until this object is
   // destroyed.
-  vector<ElfSectionReader<ElfArch>*> sections_;
+  vector<ElfSectionReader<ElfArch>*> sections_ {};
 
   // True if this is a .dwp file.
-  bool is_dwp_;
+  bool is_dwp_ {};
 
   DISALLOW_EVIL_CONSTRUCTORS(ElfReaderImpl);
 };


### PR DESCRIPTION
Patch 1/2 fixes a use-after-free found using ASan. Patch 2/2 fixes various uninitialized variable warnings that were found using valgrind. 