### PR TITLE
Add Support single binary profiles when CONFIG_PID_IN_CONTEXTIDR is not set

### DIFF
--- a/perfdata_reader.cc
+++ b/perfdata_reader.cc
@@ -432,7 +432,6 @@ absl::Status PerfDataReader::AggregateSpe(BranchFrequencies &result) const {
         // records.
         if (is_kernel_mode) pid = kKernelPid;
 
-        if (binary_mmaps_.count(pid) == 0) return;
         if (!record.event.retired || !record.op.is_br_eret) return;
 
         uint64_t from_addr = RuntimeAddressToBinaryAddress(pid, record.ip.addr);

--- a/spe_tid_pid_provider.cc
+++ b/spe_tid_pid_provider.cc
@@ -33,6 +33,7 @@ SpeTidPidProvider::SpeTidPidProvider(
       VLOG(7) << absl::StrCat("tid = ", tid, ", timestamp = ", timestamp,
                               ", pid = ", pid, "\n");
       pids.insert(std::make_pair(timestamp, pid));
+      pids_.insert(pid);
     };
 
     record(event.fork_event().pid(), event.fork_event().tid(),
@@ -73,6 +74,9 @@ absl::StatusOr<int> SpeTidPidProvider::GetPid(
   // neither are present, the context is still value-initialized and the context
   // ID is meaningless.
   if (!record.context.el1 && !record.context.el2) {
+    if (pids_.size() == 1) {
+       return *pids_.begin();
+    }
     return absl::InvalidArgumentError(
         "Cannot get PID for an SPE event with an invalid context");
   }

--- a/spe_tid_pid_provider.h
+++ b/spe_tid_pid_provider.h
@@ -41,6 +41,7 @@ class SpeTidPidProvider : public SpePidProvider {
   // TID -> (timestamp -> pid)
   absl::flat_hash_map<int, absl::btree_map<uint64_t, pid_t>> tids_to_pids_;
   quipper::PerfDataProto::TimeConvEvent time_conv_event_;
+  std::unordered_set<pid_t> pids_;
 };
 }  // namespace devtools_crosstool_autofdo
 


### PR DESCRIPTION
Support for single binary profiles is added for cases where the CONFIG_PID_IN_CONTEXTIDR kernel option is not set. This change ensures profiling can still be used in these environments.