### PR TITLE
Filter out SPE records with irrelevant PIDs

### DIFF
--- a/perfdata_reader.cc
+++ b/perfdata_reader.cc
@@ -432,6 +432,7 @@ absl::Status PerfDataReader::AggregateSpe(BranchFrequencies &result) const {
         // records.
         if (is_kernel_mode) pid = kKernelPid;
 
+        if (binary_mmaps_.count(pid) == 0) return;
         if (!record.event.retired || !record.op.is_br_eret) return;
 
         uint64_t from_addr = RuntimeAddressToBinaryAddress(pid, record.ip.addr);


### PR DESCRIPTION
975aadd929cbe4995773e3676df1319f95d10916 added support for single binary profiles to SPE-based AFDO profile generation, but it broke support for multi-binary profiles by removing PID-based filtering.

Re-add the line that filters out non-mapped PIDs, as even single-binary profiles should include mmap entries for the profiled binary.